### PR TITLE
refactor: move globals to modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "telegram-planfix-bot",
+  "name": "telegram-functions-bot",
   "version": "main",
   "description": "",
   "type": "module",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,0 +1,9 @@
+import { Telegraf } from 'telegraf';
+import { useConfig } from './config';
+
+const config = useConfig();
+const bot = new Telegraf(config.auth.bot_token);
+
+export function useBot() {
+  return bot;
+}

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,5 +1,5 @@
 import { Telegraf } from 'telegraf';
-import { useConfig } from './config';
+import { useConfig } from './config.ts';
 
 const config = useConfig();
 const bot = new Telegraf(config.auth.bot_token);

--- a/src/config.ts
+++ b/src/config.ts
@@ -122,3 +122,13 @@ function generateDiff(oldStr: string, newStr: string): string {
 
   return diffLines.join('\n');
 }
+
+let config = {} as ConfigType;
+export function useConfig(): ConfigType {
+  if (!config.bot_token) reloadConfig();
+  return config;
+}
+export function reloadConfig(): ConfigType {
+  config = readConfig();
+  retkurn config;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -125,10 +125,10 @@ function generateDiff(oldStr: string, newStr: string): string {
 
 let config = {} as ConfigType;
 export function useConfig(): ConfigType {
-  if (!config.bot_token) reloadConfig();
+  if (!config?.auth?.bot_token) reloadConfig();
   return config;
 }
 export function reloadConfig(): ConfigType {
   config = readConfig();
-  retkurn config;
+  return config;
 }

--- a/src/helpers/google.ts
+++ b/src/helpers/google.ts
@@ -1,8 +1,8 @@
 import {google} from "googleapis";
-import {threads} from "../index.ts";
+import {useThreads} from "../threads.ts";
 import {Credentials} from "google-auth-library/build/src/auth/credentials";
 import fs from "fs";
-import {readConfig} from "../config.ts";
+import {useConfig} from "../config.ts";
 import {OAuth2Client} from "google-auth-library/build/src/auth/oauth2client";
 import {Message} from "telegraf/types";
 import http from "http";
@@ -53,7 +53,7 @@ export function saveUserGoogleCreds(creds?: Credentials | null, user_id?: number
 
 export async function ensureAuth(user_id: number): Promise<OAuth2Client | GoogleAuth> {
   const creds = getUserGoogleCreds(user_id);
-  const config = readConfig();
+  const config = useConfig();
 
   // Check if the user has credentials
   if (creds && creds.expiry_date && creds.expiry_date > Date.now()) {
@@ -111,7 +111,7 @@ export function createAuthServer(oauth2Client: OAuth2Client, msg: Message.TextMe
           res.end('Authentication successful! You can close this window.');
           server.close();
 
-          addOauthToThread(oauth2Client, threads, msg);
+          addOauthToThread(oauth2Client, useThreads(), msg);
           void sendTelegramMessage(msg.chat.id, 'Google auth successful, you can use google functions');
         });
       } else {
@@ -162,6 +162,6 @@ export async function commandGoogleOauth(msg: Message.TextMessage) {
     return
   }
 
-  addOauthToThread(authClient, threads, msg);
+  addOauthToThread(authClient, useThreads(), msg);
   await sendTelegramMessage(msg.chat?.id, 'Google auth successful, now you can use google functions');
 }

--- a/src/helpers/history.ts
+++ b/src/helpers/history.ts
@@ -1,7 +1,7 @@
 import {Message} from "telegraf/types";
 import {CompletionParamsType} from "../types.ts";
 import OpenAI from "openai";
-import {threads} from "../index.ts";
+import {useThreads} from "../threads.ts";
 
 export function addToHistory({msg, answer, completionParams}: {
   msg: Message.TextMessage;
@@ -9,6 +9,7 @@ export function addToHistory({msg, answer, completionParams}: {
   completionParams?: CompletionParamsType;
 }) {
   const key = msg.chat?.id || 0
+  const threads = useThreads();
   if (!threads[key]) {
     threads[key] = {
       id: key,
@@ -35,6 +36,7 @@ export function addToHistory({msg, answer, completionParams}: {
 }
 
 export function forgetHistory(chatId: number) {
+  const threads = useThreads();
   if (threads[chatId]) {
     threads[chatId].messages = [];
   }

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -1,0 +1,2 @@
+export const threads = {};
+

--- a/src/threads.ts
+++ b/src/threads.ts
@@ -1,2 +1,7 @@
-export const threads = {};
+import {ThreadStateType} from "./types.ts";
 
+const threads = {} as { [key: number]: ThreadStateType }
+
+export function useThreads() {
+  return threads;
+}


### PR DESCRIPTION
Fixes #39

Refactor global variables to modules and update imports accordingly.

* **Add `src/bot.ts`**: Export `bot` and initialize it with `Telegraf` and `config.auth.bot_token`.
* **Modify `src/config.ts`**: Remove `config` variable and its initialization. Export `useConfig` function to read and return the config.
* **Add `src/threads.ts`**: Export `threads` and initialize it as an empty object.
* **Update imports in helper files**:
  - `src/helpers/google.ts`: Replace imports of `threads` and `config` with `useThreads` and `useConfig`.
  - `src/helpers/gpt.ts`: Replace imports of `bot` and `threads` with `useBot` and `useThreads`.
  - `src/helpers/history.ts`: Replace import of `threads` with `useThreads`.
  - `src/helpers/telegram.ts`: Replace imports of `bot` and `config` with `useBot` and `useConfig`.
* **Modify `src/index.ts`**: Remove `bot`, `config`, and `threads` variables. Import `useBot`, `useConfig`, and `useThreads`. Update references to `bot`, `config`, and `threads` to use the new functions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/popstas/telegram-functions-bot/pull/40?shareId=5a7a87ed-bec5-454d-aaa4-9920c6f2614c).