### PR TITLE
feat: support final message on forget tool

### DIFF
--- a/src/helpers/gpt.ts
+++ b/src/helpers/gpt.ts
@@ -323,16 +323,7 @@ export async function processToolResponse({
 
   if (isForget) {
     forgetHistory(msg.chat.id);
-    if (forgetMessage) {
-      void sendTelegramMessage(
-        msg.chat.id,
-        forgetMessage,
-        undefined,
-        undefined,
-        chatConfig,
-      );
-    }
-    return { content: "Forgot history, task completed." };
+    return { content: forgetMessage || "Forgot history, task completed." };
   }
 
   gptContext.messages = await buildMessages(

--- a/src/tools/forget.ts
+++ b/src/tools/forget.ts
@@ -1,19 +1,16 @@
-import {
-  aiFunction,
-  AIFunctionsProvider,
-} from '@agentic/core'
-import {z} from 'zod'
-import {ConfigChatType, ThreadStateType} from "../types.ts";
-import {forgetHistory} from "../helpers/history.ts";
-import {log} from "../helpers.ts";
+import { aiFunction, AIFunctionsProvider } from "@agentic/core";
+import { z } from "zod";
+import { ConfigChatType, ThreadStateType } from "../types.ts";
+import { forgetHistory } from "../helpers/history.ts";
+import { log } from "../helpers.ts";
 
 // No arguments needed for forget tool
 
-export const description = 'Clear the conversation history and start fresh';
+export const description = "Clear the conversation history and start fresh";
 
 export class ForgetClient extends AIFunctionsProvider {
-  protected readonly configChat: ConfigChatType
-  protected readonly thread: ThreadStateType
+  protected readonly configChat: ConfigChatType;
+  protected readonly thread: ThreadStateType;
 
   constructor(configChat: ConfigChatType, thread: ThreadStateType) {
     super();
@@ -22,34 +19,40 @@ export class ForgetClient extends AIFunctionsProvider {
   }
 
   @aiFunction({
-    name: 'forget',
+    name: "forget",
     description,
-    inputSchema: z.object({}) // No parameters needed
+    inputSchema: z.object({
+      message: z
+        .string()
+        .optional()
+        .describe("Optional final message to send to the user"),
+    }),
   })
-  async forget() {
+  async forget({ message }: { message?: string }) {
     try {
       forgetHistory(this.thread.id);
-      log({ 
+      log({
         msg: `Forgot history for chat ${this.thread.id}`,
-        logLevel: 'info',
+        logLevel: "info",
         chatId: this.thread.id,
-        role: 'system'
+        role: "system",
       });
-      return { content: 'Forgot history' };
+      return { content: message || "Forgot history" };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      log({ 
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      log({
         msg: `Failed to forget history: ${errorMessage}`,
-        logLevel: 'error',
+        logLevel: "error",
         chatId: this.thread.id,
-        role: 'system'
+        role: "system",
       });
       return { content: `Failed to forget history: ${errorMessage}` };
     }
   }
 
   options_string() {
-    return '`Clear conversation history:`';
+    return "`Clear conversation history:`";
   }
 }
 


### PR DESCRIPTION
## Summary
- extend `forget` tool to accept optional message
- send any provided message after forgetting chat history

## Testing
- `npm run lint:fix`
- `npm run lint` *(fails: 39 errors)*
- `npm run format:check src/tools/forget.ts src/helpers/gpt.ts`
- `npm test` *(fails: 15 failed tests)*
- `npm run typecheck` *(fails: config type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841ac5db0f0832ca2297819e12e3296