### PR TITLE
Add photo OCR and media handlers

### DIFF
--- a/src/helpers/onPhoto.ts
+++ b/src/helpers/onPhoto.ts
@@ -1,0 +1,20 @@
+import { Context } from "telegraf";
+import { Message } from "telegraf/types";
+import onMessage from "./onMessage.ts";
+import { recognizeImageText } from "./vision.ts";
+
+export default async function onPhoto(ctx: Context) {
+  const msg = ctx.message as unknown as Message.PhotoMessage;
+  if (!msg || !msg.photo?.length) return;
+  const text = await recognizeImageText(msg);
+  const caption = msg.caption ? msg.caption + "\n" : "";
+  const newMsg = {
+    ...msg,
+    text: caption + text,
+  } as unknown as Message.TextMessage;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (ctx as any).message = newMsg;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (ctx.update as any).message = newMsg;
+  await onMessage(ctx);
+}

--- a/src/helpers/onUnsupported.ts
+++ b/src/helpers/onUnsupported.ts
@@ -1,0 +1,14 @@
+import { Context } from "telegraf";
+import { Message } from "telegraf/types";
+import { sendTelegramMessage } from "./telegram.ts";
+
+export default async function onUnsupported(ctx: Context) {
+  const msg = ctx.message as Message.AudioMessage | Message.VoiceMessage;
+  if (!msg) return;
+  await sendTelegramMessage(
+    msg.chat.id,
+    "Извините, обработка аудио не поддерживается",
+    {},
+    ctx,
+  );
+}

--- a/src/helpers/vision.ts
+++ b/src/helpers/vision.ts
@@ -1,0 +1,32 @@
+import { Message } from "telegraf/types";
+import { useBot } from "../bot.ts";
+import { useApi } from "./useApi.ts";
+
+export async function recognizeImageText(
+  msg: Message.PhotoMessage,
+): Promise<string> {
+  const photo = msg.photo[msg.photo.length - 1];
+  const link = await useBot().telegram.getFileLink(photo.file_id);
+  const api = useApi();
+  try {
+    const res = await api.chat.completions.create({
+      model: "gpt-4-vision-preview",
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Извлеки текст с изображения. Ответь только текстом.",
+            },
+            { type: "image_url", image_url: { url: link.toString() } },
+          ],
+        },
+      ],
+    });
+    return res.choices[0]?.message?.content?.trim() || "";
+  } catch (e) {
+    console.error("vision error", e);
+    return "";
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,32 +1,32 @@
-import {Context} from 'telegraf'
-import {message, editedMessage} from 'telegraf/filters'
-import {Message} from 'telegraf/types'
-import {
-  ConfigChatType,
-} from './types.ts'
-import {validateConfig, writeConfig, watchConfigChanges} from './config.ts'
-import {initCommands} from './commands.ts'
-import {log} from './helpers.ts';
-import express from 'express';
-import { useBot } from './bot';
-import { useConfig } from './config';
+import { Context } from "telegraf";
+import { message, editedMessage } from "telegraf/filters";
+import { Message } from "telegraf/types";
+import { ConfigChatType } from "./types.ts";
+import { validateConfig, writeConfig, watchConfigChanges } from "./config.ts";
+import { initCommands } from "./commands.ts";
+import { log } from "./helpers.ts";
+import express from "express";
+import { useBot } from "./bot";
+import { useConfig } from "./config";
 import onMessage from "./helpers/onMessage.ts";
-import {useLastCtx} from "./helpers/lastCtx.ts";
+import onPhoto from "./helpers/onPhoto.ts";
+import onUnsupported from "./helpers/onUnsupported.ts";
+import { useLastCtx } from "./helpers/lastCtx.ts";
 
-process.on('uncaughtException', (error, source) => {
-  console.log('Uncaught Exception:', error)
-  console.log('source:', source)
-})
+process.on("uncaughtException", (error, source) => {
+  console.log("Uncaught Exception:", error);
+  console.log("source:", source);
+});
 
-void start()
+void start();
 
 async function start() {
   // global
   const config = useConfig();
 
   if (!validateConfig(config)) {
-    console.log('Invalid config, exiting...')
-    process.exit(1)
+    console.log("Invalid config, exiting...");
+    process.exit(1);
   }
   watchConfigChanges();
 
@@ -34,47 +34,55 @@ async function start() {
     await launchBot(config.auth.bot_token, config.bot_name);
     // log({msg: 'bot started'});
 
-    const chatBots = config.chats.filter(c => c.bot_token && c.bot_name);
-    chatBots.forEach(c => launchBot(c.bot_token!, c.bot_name!));
+    const chatBots = config.chats.filter((c) => c.bot_token && c.bot_name);
+    chatBots.forEach((c) => launchBot(c.bot_token!, c.bot_name!));
 
     // Initialize HTTP server
     initHttp();
   } catch (error: unknown) {
-    console.error('Error during bot startup:', error);
-    console.log('restart after 10 seconds...')
-    setTimeout(start, 10000)
+    console.error("Error during bot startup:", error);
+    console.log("restart after 10 seconds...");
+    setTimeout(start, 10000);
   }
 }
 
 async function launchBot(bot_token: string, bot_name: string) {
   const config = useConfig();
   const bot = useBot(bot_token);
-  bot.help(async ctx => ctx.reply('https://github.com/popstas/telegram-functions-bot'))
-  await initCommands(bot)
-  bot.on([message('text'), editedMessage('text')], onMessage)
+  bot.help(async (ctx) =>
+    ctx.reply("https://github.com/popstas/telegram-functions-bot"),
+  );
+  await initCommands(bot);
+  bot.on([message("text"), editedMessage("text")], onMessage);
+  bot.on(message("photo"), onPhoto);
+  bot.on(message("voice"), onUnsupported);
+  bot.on(message("audio"), onUnsupported);
 
-  bot.action('add_chat', async (ctx) => {
+  bot.action("add_chat", async (ctx) => {
     const chatId = ctx.chat?.id;
     // @ts-expect-error title may not exist on chat type
     const chatName = ctx.chat?.title || `Chat ${chatId}`;
     if (!chatId) return;
 
-    const newChat = {name: chatName, id: chatId} as ConfigChatType;
+    const newChat = { name: chatName, id: chatId } as ConfigChatType;
     config.chats.push(newChat);
     writeConfig(undefined, config);
     await ctx.reply(`Chat added: ${chatName}`);
   });
 
   void bot.launch();
-  log({msg: `bot started: ${bot_name}`});
+  log({ msg: `bot started: ${bot_name}` });
   return bot;
 }
 
 function initHttp() {
   // Validate HTTP configuration
   if (!useConfig().http) {
-    log({msg: `Invalid http configuration in config, skip http server init`, logLevel: 'warn'});
-    return
+    log({
+      msg: `Invalid http configuration in config, skip http server init`,
+      logLevel: "warn",
+    });
+    return;
   }
 
   const port = useConfig().http.port || 7586;
@@ -84,73 +92,88 @@ function initHttp() {
   app.use(express.json());
 
   // Add /ping test route
-  app.get('/ping', (req, res) => {
-    res.send('pong');
+  app.get("/ping", (req, res) => {
+    res.send("pong");
   });
 
   // Add route handler to create a virtual message and call onMessage
   // @ts-expect-error express types need proper request/response typing
-  app.post('/telegram/:chatId', telegramPostHandler);
+  app.post("/telegram/:chatId", telegramPostHandler);
   // @ts-expect-error express types need proper request/response typing
-  app.get('/telegram/test', telegramPostHandlerTest);
+  app.get("/telegram/test", telegramPostHandlerTest);
 
   app.listen(port, () => {
     console.log(`Express server listening on port ${port}`);
   });
 }
 
-async function telegramPostHandlerTest(req: express.Request, res: express.Response) {
-  req.params = {chatId: "-4534736935"}
-  req.body = {text: 'На сервере высокий load average. Проверь, есть ли необычное в процессах, скажи да или нет noconfirm'}
-  return telegramPostHandler(req, res)
+async function telegramPostHandlerTest(
+  req: express.Request,
+  res: express.Response,
+) {
+  req.params = { chatId: "-4534736935" };
+  req.body = {
+    text: "На сервере высокий load average. Проверь, есть ли необычное в процессах, скажи да или нет noconfirm",
+  };
+  return telegramPostHandler(req, res);
 }
 
-async function telegramPostHandler(req: express.Request, res: express.Response) {
-  const {chatId} = req.params;
-  const {text} = req.body || '';
+async function telegramPostHandler(
+  req: express.Request,
+  res: express.Response,
+) {
+  const { chatId } = req.params;
+  const { text } = req.body || "";
 
-  log({msg: `POST /telegram/${chatId}: ${text}`})
+  log({ msg: `POST /telegram/${chatId}: ${text}` });
 
   if (!text) {
-    return res.status(400).send('Message text is required.');
+    return res.status(400).send("Message text is required.");
   }
 
-  const chatConfig = useConfig().chats.find(chat => chat.id === parseInt(chatId));
+  const chatConfig = useConfig().chats.find(
+    (chat) => chat.id === parseInt(chatId),
+  );
   if (!chatConfig) {
-    log({msg: `http: Chat ${chatId} not found in config`, logLevel: 'warn'});
-    return res.status(400).send('Wrong chat_id')
+    log({ msg: `http: Chat ${chatId} not found in config`, logLevel: "warn" });
+    return res.status(400).send("Wrong chat_id");
   }
 
-  const chat = {id: parseInt(chatId), title: chatConfig.name}
-  const from = {username: useConfig().http.telegram_from_username}
+  const chat = { id: parseInt(chatId), title: chatConfig.name };
+  const from = { username: useConfig().http.telegram_from_username };
   const virtualCtx = {
     chat: {
       id: chat.id,
       title: chat.title,
-      type: 'supergroup' as const
+      type: "supergroup" as const,
     },
     update: {
       update_id: Date.now(),
       message: {
-        text, 
+        text,
         chat: {
           id: chat.id,
           title: chat.title,
-          type: 'supergroup' as const
+          type: "supergroup" as const,
         },
         from,
         message_id: Date.now(),
-        date: Math.floor(Date.now() / 1000)
-      } as Message.TextMessage
-    }
+        date: Math.floor(Date.now() / 1000),
+      } as Message.TextMessage,
+    },
   } as unknown as Context;
 
   const ctx = useLastCtx() as Context & {
     expressRes?: Express.Response;
-  }
+  };
   if (!ctx) {
-    log({msg: `http: lastCtx not found`, logLevel: 'warn', chatId: chat.id, chatTitle: chat.title});
-    return res.status(500).send('lastCtx not found.');
+    log({
+      msg: `http: lastCtx not found`,
+      logLevel: "warn",
+      chatId: chat.id,
+      chatTitle: chat.title,
+    });
+    return res.status(500).send("lastCtx not found.");
   }
 
   // Create a new context object instead of modifying the readonly properties
@@ -159,8 +182,11 @@ async function telegramPostHandler(req: express.Request, res: express.Response) 
     update: virtualCtx.update,
     chat: virtualCtx.chat,
     // replace to fake action
-    persistentChatAction: async (action: string, callback: () => Promise<void>) => {
-      log({msg: `persistentChatAction stub`});
+    persistentChatAction: async (
+      action: string,
+      callback: () => Promise<void>,
+    ) => {
+      log({ msg: `persistentChatAction stub` });
       return await callback();
     },
   } as Context & {
@@ -168,17 +194,21 @@ async function telegramPostHandler(req: express.Request, res: express.Response) 
   };
 
   try {
-    newCtx.expressRes = res
-    await onMessage(newCtx as Context, undefined, async (sentMsg: Message.TextMessage) => {
-      if (sentMsg) {
-        const text = (sentMsg as Message.TextMessage).text;
-        res.end(text);
-      } else {
-        res.status(500).send('Error sending message.');
-      }
-      // await useBot().telegram.sendMessage(chat.id, 'test - ' + text);
-    });
+    newCtx.expressRes = res;
+    await onMessage(
+      newCtx as Context,
+      undefined,
+      async (sentMsg: Message.TextMessage) => {
+        if (sentMsg) {
+          const text = (sentMsg as Message.TextMessage).text;
+          res.end(text);
+        } else {
+          res.status(500).send("Error sending message.");
+        }
+        // await useBot().telegram.sendMessage(chat.id, 'test - ' + text);
+      },
+    );
   } catch {
-    res.status(500).send('Error sending message.');
+    res.status(500).send("Error sending message.");
   }
 }


### PR DESCRIPTION
## Summary
- add handler for photo messages that extracts image text via GPT-4 vision
- respond to voice and audio with a generic unsupported message
- register new handlers in bot startup

## Testing
- `npm run lint:fix -- src/index.ts src/helpers/onPhoto.ts src/helpers/onUnsupported.ts src/helpers/vision.ts`
- `npm run lint -- src/index.ts src/helpers/onPhoto.ts src/helpers/onUnsupported.ts src/helpers/vision.ts`
- `npm run format:check src/index.ts src/helpers/onPhoto.ts src/helpers/onUnsupported.ts src/helpers/vision.ts`
- `npm test` *(fails: Too Many Requests; TypeError mocks)*
- `npm run typecheck` *(fails: Property 'models' is missing in type 'ConfigType')*


------
https://chatgpt.com/codex/tasks/task_e_684201f8a230832c90f5c3bfaa546194