### PR TITLE
Add per-chat http token

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ npm run agent <agent_name> "your text"
 ### HTTP endpoint
 
 POST `/agent/:agentName` with JSON `{ "text": "hi", "webhook": "<url>" }`.
-Use header `Authorization: Bearer <auth_token>`.
+Use header `Authorization: Bearer <http_token>`.
 
 ### HTTP tool call
 

--- a/src/cli-agent.ts
+++ b/src/cli-agent.ts
@@ -1,5 +1,7 @@
 // TODO: cli is doing cold start, it's too long, need lightweight cli that will call running agent
 import { runAgent } from "./agent-runner.ts";
+import { fileURLToPath } from "url";
+import { resolve } from "path";
 
 export const runCliAgent = (args: string[]) => {
   const [agentName, ...t] = args;
@@ -16,17 +18,15 @@ export const runCliAgent = (args: string[]) => {
     });
 };
 
-import { fileURLToPath } from 'url';
-import { resolve } from 'path';
-
 // Check if this file is being run directly (not imported)
 const isMain = (() => {
   const currentFilePath = fileURLToPath(import.meta.url);
-  const scriptPath = process.argv[1] ? resolve(process.cwd(), process.argv[1]) : '';
+  const scriptPath = process.argv[1]
+    ? resolve(process.cwd(), process.argv[1])
+    : "";
   return scriptPath === currentFilePath;
 })();
 
 if (isMain) {
   runCliAgent(process.argv.slice(2));
 }
-

--- a/src/config.ts
+++ b/src/config.ts
@@ -118,7 +118,7 @@ export function generateConfig(): ConfigType {
     http: {
       port: 7586,
       telegram_from_username: "second_bot_name",
-      auth_token: "change_me",
+      http_token: "change_me",
     },
     mqtt: {
       host: "localhost",

--- a/src/helpers/onTextMessage.ts
+++ b/src/helpers/onTextMessage.ts
@@ -75,15 +75,15 @@ export default async function onTextMessage(
 
   // Store the current message count to track if new messages arrive
   const historyLength = thread.messages.length;
-  
+
   // Start responding immediately
   let responseCompleted = false;
   const responsePromise = answerToMessage(ctx, msg, chat, extraMessageParams);
-  
+
   // Set up a timeout to check for new messages
   const timer = setTimeout(async () => {
     if (responseCompleted) return;
-    
+
     // If no new messages, complete the response
     if (thread.messages.length === historyLength) {
       responseCompleted = true;
@@ -97,7 +97,7 @@ export default async function onTextMessage(
       responsePromise.catch(() => {}); // Prevent unhandled promise rejection
     }
   }, 5000);
-  
+
   // Clean up the timer when the response completes
   responsePromise.finally(() => {
     clearTimeout(timer);

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,11 @@ import onPhoto from "./helpers/onPhoto.ts";
 import onAudio from "./helpers/onAudio.ts";
 import onUnsupported from "./helpers/onUnsupported.ts";
 import { useLastCtx } from "./helpers/lastCtx.ts";
-import { agentGetHandler, agentPostHandler, toolPostHandler } from "./httpHandlers.ts";
+import {
+  agentGetHandler,
+  agentPostHandler,
+  toolPostHandler,
+} from "./httpHandlers.ts";
 import { useMqtt } from "./mqtt.ts";
 
 process.on("uncaughtException", (error, source) => {
@@ -64,7 +68,7 @@ async function launchBot(bot_token: string, bot_name: string) {
   try {
     const config = useConfig();
     const bot = useBot(bot_token);
-    
+
     // Set up help command
     bot.help(async (ctx) =>
       ctx.reply("https://github.com/popstas/telegram-functions-bot"),
@@ -97,33 +101,33 @@ async function launchBot(bot_token: string, bot_name: string) {
     });
 
     // Start the bot
-    void bot.launch().catch(error => {
-      log({ 
+    void bot.launch().catch((error) => {
+      log({
         msg: `[${bot_name}] Error during bot launch: ${error instanceof Error ? error.message : String(error)}`,
-        logLevel: 'error' 
+        logLevel: "error",
       });
     });
-    
+
     log({ msg: `bot started: ${bot_name}` });
     return bot;
   } catch (error: unknown) {
-    if (error && typeof error === 'object' && 'response' in error) {
+    if (error && typeof error === "object" && "response" in error) {
       const errorWithResponse = error as { response?: { statusCode?: number } };
       if (errorWithResponse.response?.statusCode === 401) {
-        log({ 
+        log({
           msg: `[${bot_name}] Error: Invalid bot token (401 Unauthorized). Please check your bot token in the config.`,
-          logLevel: 'error' 
+          logLevel: "error",
         });
       } else {
-        log({ 
+        log({
           msg: `[${bot_name}] Error during bot launch: ${error instanceof Error ? error.message : String(error)}`,
-          logLevel: 'error' 
+          logLevel: "error",
         });
       }
     } else {
-      log({ 
+      log({
         msg: `[${bot_name}] Error during bot launch: ${error instanceof Error ? error.message : String(error)}`,
-        logLevel: 'error' 
+        logLevel: "error",
       });
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export type ConfigChatType = {
   buttons?: ConfigChatButtonType[];
   buttonsSync?: ButtonsSyncConfigType;
   buttonsSynced?: ConfigChatButtonType[];
+  http_token?: string;
   tools?: (string | ToolBotType)[];
   chatParams: ChatParamsType;
   toolParams: ToolParamsType;
@@ -95,7 +96,7 @@ export type ConfigType = {
 export type HttpConfigType = {
   port?: number;
   telegram_from_username?: string;
-  auth_token?: string;
+  http_token?: string;
   webhook?: string;
 };
 

--- a/testConfig.yml
+++ b/testConfig.yml
@@ -38,3 +38,4 @@ chats:
 http:
   port: 7586
   telegram_from_username: second_bot_name
+  http_token: change_me

--- a/tests/runAgent.test.ts
+++ b/tests/runAgent.test.ts
@@ -20,7 +20,10 @@ const { runCliAgent } = await import("../src/cli-agent.ts");
 import type { runAgent } from "../src/agent-runner";
 
 // Mock the agent-runner module
-const mockRunAgent = jest.fn<ReturnType<typeof runAgent>, Parameters<typeof runAgent>>();
+const mockRunAgent = jest.fn<
+  ReturnType<typeof runAgent>,
+  Parameters<typeof runAgent>
+>();
 
 jest.mock("../src/agent-runner.ts", () => ({
   runAgent: (...args: Parameters<typeof runAgent>) => mockRunAgent(...args),
@@ -45,7 +48,7 @@ describe.skip("CLI Agent", () => {
   it("calls runAgent with correct arguments and returns result", async () => {
     const progress = jest.fn();
     const result = await mockRunAgent("test", "test message", progress);
-    
+
     expect(mockRunAgent).toHaveBeenCalledWith("test", "test message", progress);
     expect(result).toBe("test response");
   });
@@ -55,18 +58,20 @@ describe.skip("CLI Agent", () => {
   });
 
   it("handles successful agent execution", async () => {
-    const consoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
-    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
-    
+    const consoleLog = jest.spyOn(console, "log").mockImplementation(() => {});
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
     await runCliAgent(["test", "test message"]);
-    
+
     expect(mockRunAgent).toHaveBeenCalledWith(
       "test",
       "test message",
-      expect.any(Function)
+      expect.any(Function),
     );
     expect(consoleLog).toHaveBeenCalledWith("test response");
-    
+
     consoleLog.mockRestore();
     consoleError.mockRestore();
   });

--- a/tests/toolEndpoint.test.ts
+++ b/tests/toolEndpoint.test.ts
@@ -55,7 +55,9 @@ describe("toolPostHandler", () => {
       module: {
         call: jest.fn().mockReturnValue({
           functions: {
-            get: () => async (args: string) => ({ content: `echo ${args}` }),
+            get: () => async (args: string) => ({
+              content: JSON.stringify([{ text: args }]),
+            }),
           },
           toolSpecs: { type: "function", function: { name: "echo" } },
         }),
@@ -93,7 +95,7 @@ describe("toolPostHandler", () => {
 
     const req = {
       params: { agentName: "agent", toolName: "echo" },
-      body: { args: { a: 1 } },
+      body: { a: 1 },
       headers: { authorization: "Bearer token" },
       query: {},
       get: () => "",
@@ -105,9 +107,7 @@ describe("toolPostHandler", () => {
     await toolPostHandler(req, res);
 
     // Check that the response is a JSON object with the expected content
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ args: { a: 1 } }),
-    );
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ a: 1 }));
   });
 
   it("uses chat http_token when present", async () => {
@@ -126,7 +126,7 @@ describe("toolPostHandler", () => {
 
     const req = {
       params: { agentName: "agent", toolName: "echo" },
-      body: { args: { b: 2 } },
+      body: { b: 2 },
       headers: { authorization: "Bearer chat" },
       query: {},
       get: () => "",


### PR DESCRIPTION
## Summary
- rename `auth_token` to `http_token`
- allow chat-specific `http_token` and check it before global
- document new header and update sample config
- test HTTP token priority

## Testing
- `npm run format`
- `npm run test-full` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6849bd93f824832cb12715e6e21d7b79