### PR TITLE
Centralize OpenAI calls with llmCall

### DIFF
--- a/src/helpers/gpt.ts
+++ b/src/helpers/gpt.ts
@@ -13,5 +13,6 @@ export {
 export {
   handleModelAnswer,
   processToolResults,
+  llmCall,
   requestGptAnswer,
 } from "./gpt/llm.ts";

--- a/src/helpers/vision.ts
+++ b/src/helpers/vision.ts
@@ -1,6 +1,6 @@
 import { Message } from "telegraf/types";
 import { useBot } from "../bot.ts";
-import { useApi } from "./useApi.ts";
+import { llmCall } from "./gpt.ts";
 import { useConfig } from "../config.ts";
 
 export async function recognizeImageText(
@@ -8,7 +8,7 @@ export async function recognizeImageText(
 ): Promise<string> {
   const photo = msg.photo[msg.photo.length - 1];
   const link = await useBot().telegram.getFileLink(photo.file_id);
-  const api = useApi();
+
   const config = useConfig();
   const model = config?.vision?.model || "";
   if (!model) return "";
@@ -17,20 +17,23 @@ export async function recognizeImageText(
   if (msg.caption) prompt = msg.caption;
 
   try {
-    const res = await api.chat.completions.create({
-      model,
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "text",
-              text: prompt,
-            },
-            { type: "image_url", image_url: { url: link.toString() } },
-          ],
-        },
-      ],
+    const { res } = await llmCall({
+      apiParams: {
+        model,
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: prompt,
+              },
+              { type: "image_url", image_url: { url: link.toString() } },
+            ],
+          },
+        ],
+      },
+      modelName: model,
     });
     return res.choices[0]?.message?.content?.trim() || "";
   } catch (e) {

--- a/src/tools/brainstorm.ts
+++ b/src/tools/brainstorm.ts
@@ -8,7 +8,7 @@ import {
   ThreadStateType,
 } from "../types.ts";
 import { buildMessages } from "../helpers/gpt.ts";
-import { useApi } from "../helpers/useApi.ts";
+import { llmCall } from "../helpers/gpt.ts";
 
 type ToolArgsType = {
   systemMessage: string;
@@ -52,13 +52,12 @@ export class BrainstormClient extends AIFunctionsProvider {
     const thread = this.thread;
     const messages = await buildMessages(systemMessage, thread.messages);
 
-    const api = useApi();
-    const res = await api.chat.completions.create({
-      messages,
-      model: thread.completionParams?.model || "gpt-4o-mini",
-      temperature: thread.completionParams?.temperature,
-      // tools: isNoTool ? undefined : tools,
-      // tool_choice: isNoTool ? undefined : 'auto',
+    const { res } = await llmCall({
+      apiParams: {
+        messages,
+        model: thread.completionParams?.model || "gpt-4o-mini",
+        temperature: thread.completionParams?.temperature,
+      },
     });
 
     const content =


### PR DESCRIPTION
## Summary
- add `llmCall` helper
- refactor request/vision/brainstorm functions to use it
- export new helper

## Testing
- `npm run format`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_6849cf39ba88832c9d6e52b53ef5a998