### PR TITLE
Ensure single Langfuse trace per message

### DIFF
--- a/src/helpers/onPhoto.ts
+++ b/src/helpers/onPhoto.ts
@@ -20,7 +20,7 @@ export default async function onPhoto(ctx: Context) {
   const access = await checkAccessLevel(ctx);
   if (!access) return;
 
-  const { msg: accessMsg } = access;
+  const { msg: accessMsg, chat } = access;
   const msg = accessMsg as unknown as Message.PhotoMessage;
   if (!msg.photo?.length) return;
   const chatTitle = "title" in msg.chat ? msg.chat.title : "private_chat";
@@ -42,7 +42,7 @@ export default async function onPhoto(ctx: Context) {
 
   // Create a new message object with the recognized text
   const processPhoto = async () => {
-    const text = await recognizeImageText(msg);
+    const text = await recognizeImageText(msg, chat);
     const caption = msg.caption ? `${msg.caption}\n` : "";
 
     log({

--- a/src/helpers/vision.ts
+++ b/src/helpers/vision.ts
@@ -2,9 +2,11 @@ import { Message } from "telegraf/types";
 import { useBot } from "../bot.ts";
 import { llmCall } from "./gpt.ts";
 import { useConfig } from "../config.ts";
+import { ConfigChatType } from "../types.ts";
 
 export async function recognizeImageText(
   msg: Message.PhotoMessage,
+  chatConfig: ConfigChatType,
 ): Promise<string> {
   const photo = msg.photo[msg.photo.length - 1];
   const link = await useBot().telegram.getFileLink(photo.file_id);
@@ -34,6 +36,8 @@ export async function recognizeImageText(
         ],
       },
       modelName: model,
+      msg: msg as unknown as Message.TextMessage,
+      chatConfig,
     });
     return res.choices[0]?.message?.content?.trim() || "";
   } catch (e) {

--- a/src/tools/brainstorm.ts
+++ b/src/tools/brainstorm.ts
@@ -9,6 +9,7 @@ import {
 } from "../types.ts";
 import { buildMessages } from "../helpers/gpt.ts";
 import { llmCall } from "../helpers/gpt.ts";
+import { Message } from "telegraf/types";
 
 type ToolArgsType = {
   systemMessage: string;
@@ -52,12 +53,15 @@ export class BrainstormClient extends AIFunctionsProvider {
     const thread = this.thread;
     const messages = await buildMessages(systemMessage, thread.messages);
 
+    const msg = thread.msgs[thread.msgs.length - 1] as Message.TextMessage;
     const { res } = await llmCall({
       apiParams: {
         messages,
         model: thread.completionParams?.model || "gpt-4o-mini",
         temperature: thread.completionParams?.temperature,
       },
+      msg,
+      chatConfig: this.configChat,
     });
 
     const content =


### PR DESCRIPTION
## Summary
- keep using `msg.message_id` for Langfuse trace names
- propagate message through evaluation and tool calls

## Testing
- `npm run test-full`
- `npm run typecheck`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6849f5d61ed8832cbfee046e404d0e63