### PR TITLE
Add forgetTimeout support for CLI agent

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -3,7 +3,7 @@ import { requestGptAnswer } from "./helpers/gpt/llm.ts";
 import { ConfigChatType } from "./types.ts";
 import { Context } from "telegraf";
 import { Message } from "telegraf/types";
-import { addToHistory } from "./helpers/history.ts";
+import { addToHistory, forgetHistoryOnTimeout } from "./helpers/history.ts";
 import { log } from "./helpers.ts";
 import { agentNameToId } from "./helpers.ts";
 
@@ -40,6 +40,7 @@ export async function runAgent(
     msg,
     completionParams: chat.completionParams,
   });
+  forgetHistoryOnTimeout(chat, msg);
 
   const res = await requestGptAnswer(msg, chat as ConfigChatType, ctx);
   log({


### PR DESCRIPTION
## Summary
- introduce `forgetHistoryOnTimeout` utility to reset history after inactivity
- reuse this function in text message handler and CLI agent
- apply forget logic in agent-runner to mirror bot behaviour

## Testing
- `npm run format`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_684accd85740832c93da296a8a29c266