### PR TITLE
Enable coverage output in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,11 @@ jobs:
           node-version: 22.x
           cache: 'npm'
       - run: npm ci
-      - run: npm test
+      - run: npm run test:coverage
       - run: npm run typecheck
       - run: npm run lint src
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,8 @@ const config = {
   transformIgnorePatterns: [
     'node_modules/(?!(langfuse|@langfuse)/)',
   ],
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "tsx src/index.ts",
     "changelog": "npx conventional-changelog-cli -p angular -i CHANGELOG.md -s -r 0",
     "test": "node --no-warnings=ExperimentalWarning --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test:coverage": "npm test -- --coverage",
     "test-full": "npm run test && npm run typecheck && npm run lint src tests",
     "prepare-commit": "npm run test-full && npm run format",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- configure Jest to collect coverage reports in `coverage/`
- add a `test:coverage` npm script
- update CI workflow to run tests with coverage and upload artifacts

## Testing
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_684b4cf36ae0832cbeb2a9fc33659a6f