### PR TITLE
Refactor telegram utilities

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,11 +8,8 @@ import {
 } from "./types";
 import { generatePrivateChatConfig, useConfig, writeConfig } from "./config";
 import { useBot } from "./bot";
-import {
-  getActionUserMsg,
-  getCtxChatMsg,
-  sendTelegramMessage,
-} from "./helpers/telegram.ts";
+import { getActionUserMsg, getCtxChatMsg } from "./telegram/context.ts";
+import { sendTelegramMessage } from "./telegram/send.ts";
 import {
   getSystemMessage,
   getTokensCount,

--- a/src/handlers/access.ts
+++ b/src/handlers/access.ts
@@ -2,11 +2,8 @@ import { Context } from "telegraf";
 import { Chat, Message } from "telegraf/types";
 import { ConfigChatType } from "../types.ts";
 import { useConfig } from "../config.ts";
-import {
-  getCtxChatMsg,
-  isAdminUser,
-  sendTelegramMessage,
-} from "../helpers/telegram.ts";
+import { getCtxChatMsg } from "../telegram/context.ts";
+import { isAdminUser, sendTelegramMessage } from "../telegram/send.ts";
 import { log } from "../helpers.ts";
 
 export default async function checkAccessLevel(

--- a/src/handlers/onAudio.ts
+++ b/src/handlers/onAudio.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import tmp from "tmp";
 import onTextMessage from "./onTextMessage.ts";
 import checkAccessLevel from "./access.ts";
-import { sendTelegramMessage } from "../helpers/telegram.ts";
+import { sendTelegramMessage } from "../telegram/send.ts";
 import { convertToMp3, sendAudioWhisper } from "../helpers/stt.ts";
 import { useConfig } from "../config.ts";
 import { log } from "../helpers.ts";

--- a/src/handlers/onPhoto.ts
+++ b/src/handlers/onPhoto.ts
@@ -5,7 +5,7 @@ import checkAccessLevel from "./access.ts";
 import { recognizeImageText } from "../helpers/vision.ts";
 import { log } from "../helpers";
 import { useConfig } from "../config.ts";
-import { sendTelegramMessage } from "../helpers/telegram.ts";
+import { sendTelegramMessage } from "../telegram/send.ts";
 
 // Type guard to check if update has a message
 function isMessageUpdate(update: Update): update is Update.MessageUpdate {

--- a/src/handlers/onTextMessage.ts
+++ b/src/handlers/onTextMessage.ts
@@ -14,7 +14,7 @@ import { addOauthToThread, ensureAuth } from "../helpers/google.ts";
 import { requestGptAnswer } from "../helpers/gpt.ts";
 import checkAccessLevel from "./access.ts";
 import resolveChatButtons from "./resolveChatButtons.ts";
-import { sendTelegramMessage } from "../helpers/telegram.ts";
+import { sendTelegramMessage } from "../telegram/send.ts";
 
 export default async function onTextMessage(
   ctx: Context & { secondTry?: boolean },

--- a/src/handlers/onUnsupported.ts
+++ b/src/handlers/onUnsupported.ts
@@ -1,7 +1,7 @@
 import checkAccessLevel from "./access.ts";
 import { Context } from "telegraf";
 import { Message } from "telegraf/types";
-import { sendTelegramMessage } from "../helpers/telegram.ts";
+import { sendTelegramMessage } from "../telegram/send.ts";
 
 type SupportedMediaMessage =
   | Message.VideoMessage

--- a/src/handlers/resolveChatButtons.ts
+++ b/src/handlers/resolveChatButtons.ts
@@ -5,7 +5,7 @@ import {
   ConfigChatType,
   ThreadStateType,
 } from "../types.ts";
-import { sendTelegramMessage } from "../helpers/telegram.ts";
+import { sendTelegramMessage } from "../telegram/send.ts";
 
 export default async function resolveChatButtons(
   ctx: Context,

--- a/src/helpers/google.ts
+++ b/src/helpers/google.ts
@@ -10,7 +10,7 @@ import url from "url";
 import { GaxiosError } from "gaxios";
 import { GoogleAuth } from "google-auth-library";
 import { ThreadStateType } from "../types.ts";
-import { sendTelegramMessage } from "./telegram.ts";
+import { sendTelegramMessage } from "../telegram/send.ts";
 
 interface GoogleCredsMap {
   [key: number]: Credentials;

--- a/src/helpers/gpt/llm.ts
+++ b/src/helpers/gpt/llm.ts
@@ -9,7 +9,10 @@ import {
   ThreadStateType,
 } from "../../types.ts";
 import { addToHistory, forgetHistory } from "../history.ts";
-import { sendTelegramMessage, getTelegramForwardedUser } from "../telegram.ts";
+import {
+  sendTelegramMessage,
+  getTelegramForwardedUser,
+} from "../../telegram/send.ts";
 import { useThreads } from "../../threads.ts";
 import { useApi } from "../useApi.ts";
 import useLangfuse from "../useLangfuse.ts";

--- a/src/helpers/gpt/tools.ts
+++ b/src/helpers/gpt/tools.ts
@@ -11,11 +11,11 @@ import {
 } from "../../types.ts";
 import { useBot } from "../../bot.ts";
 import { useThreads } from "../../threads.ts";
-import { sendTelegramMessage, getFullName } from "../telegram.ts";
+import { sendTelegramMessage, getFullName } from "../../telegram/send.ts";
 import { log, sendToHttp } from "../../helpers.ts";
 import useTools from "../useTools.ts";
 import useLangfuse from "../useLangfuse.ts";
-import { isAdminUser } from "../telegram.ts";
+import { isAdminUser } from "../../telegram/send.ts";
 import { useConfig } from "../../config.ts";
 import { requestGptAnswer } from "./llm.ts";
 import { publishMqttProgress } from "../../mqtt.ts";

--- a/src/helpers/history.ts
+++ b/src/helpers/history.ts
@@ -1,6 +1,6 @@
 import { Message } from "telegraf/types";
 import { CompletionParamsType, ConfigChatType } from "../types.ts";
-import { getFullName } from "./telegram.ts";
+import { getFullName } from "../telegram/send.ts";
 import OpenAI from "openai";
 import { useThreads } from "../threads.ts";
 

--- a/src/telegram/context.ts
+++ b/src/telegram/context.ts
@@ -1,0 +1,134 @@
+import { Chat, Message, Update } from "telegraf/types";
+import { Context } from "telegraf";
+import { User } from "@telegraf/types/manage";
+import { useConfig } from "../config.ts";
+import { log } from "../helpers.ts";
+import { CompletionParamsType, ConfigChatType } from "../types.ts";
+
+function isAccessAllowed(chatConfig: ConfigChatType, ctxChat: Chat) {
+  const privateChat = ctxChat as Chat.PrivateChat;
+  const allowedUsers = [
+    ...(chatConfig.privateUsers ?? useConfig().privateUsers),
+    ...(useConfig().adminUsers ?? []),
+  ];
+  const username = privateChat.username || "without_username";
+  return allowedUsers.includes(username);
+}
+
+function getChatConfig(
+  ctxChat: Chat,
+  ctx: Context,
+): ConfigChatType | undefined {
+  let chat =
+    useConfig().chats.find(
+      (c) => c.id == ctxChat?.id || c.ids?.includes(ctxChat?.id) || 0,
+    ) || ({} as ConfigChatType);
+
+  const defaultChat = useConfig().chats.find((c) => c.name === "default");
+
+  if (!chat.id) {
+    chat =
+      useConfig().chats.find((c) => c.bot_name === ctx.botInfo.username) ||
+      ({} as ConfigChatType);
+
+    if (chat.id && ctxChat?.type === "private") {
+      if (!isAccessAllowed(chat, ctxChat)) {
+        return;
+      }
+    }
+  }
+
+  if (!chat.id) {
+    if (ctxChat?.type !== "private") {
+      const chatTitle = (ctxChat as Chat.TitleChat).title;
+      log({
+        msg: `This is ${ctxChat?.type} chat, not in whitelist: ${ctxChat.title}`,
+        chatId: ctxChat.id,
+        chatTitle,
+        logLevel: "warn",
+      });
+      return;
+    }
+
+    if (defaultChat) chat = defaultChat;
+
+    if (ctxChat?.type === "private") {
+      const privateChat = ctxChat as Chat.PrivateChat;
+
+      if (!isAccessAllowed(chat, ctxChat)) {
+        return;
+      }
+
+      const userChat = useConfig().chats.find(
+        (c) => c.username === privateChat.username || "",
+      );
+      if (userChat) chat = userChat;
+    }
+  }
+
+  function mergeConfigParam<T extends Record<string, unknown>>(
+    name: keyof T,
+    from: Partial<T> | undefined,
+    to: T | undefined,
+  ) {
+    if (!from || !from[name] || !to) return;
+    to[name] = to[name]
+      ? ({
+          ...(from[name] as object),
+          ...(to[name] as object),
+        } as T[typeof name])
+      : from[name];
+  }
+
+  mergeConfigParam<{ completionParams: CompletionParamsType }>(
+    "completionParams",
+    useConfig() as Partial<{ completionParams: CompletionParamsType }>,
+    chat,
+  );
+
+  if (chat && defaultChat) {
+    chat = { ...defaultChat, ...chat };
+    mergeConfigParam<{ completionParams: CompletionParamsType }>(
+      "completionParams",
+      defaultChat,
+      chat,
+    );
+  }
+
+  return chat;
+}
+
+export function getActionUserMsg(ctx: Context): { user?: User; msg?: Message } {
+  if (Object.prototype.hasOwnProperty.call(ctx, "update")) {
+    const updateQuery = ctx.update as Update.CallbackQueryUpdate;
+    const user = updateQuery.callback_query.from;
+    const msg = updateQuery.callback_query.message;
+    return { user, msg };
+  }
+  return {};
+}
+
+export function getCtxChatMsg(ctx: Context): {
+  chat: ConfigChatType | undefined;
+  msg: Message.TextMessage | undefined;
+} {
+  let ctxChat: Chat | undefined;
+  let msg: Message.TextMessage | undefined;
+
+  if (Object.prototype.hasOwnProperty.call(ctx, "update")) {
+    const updateEdited = ctx.update as Update.EditedMessageUpdate;
+    const updateNew = ctx.update as Update.MessageUpdate;
+    msg = (updateEdited.edited_message ||
+      updateNew.message) as Message.TextMessage;
+    ctxChat = msg?.chat;
+  }
+
+  if (!ctxChat) {
+    console.log("no ctx chat detected");
+    return { chat: undefined, msg: undefined };
+  }
+
+  const chat = getChatConfig(ctxChat, ctx);
+
+  return { chat, msg };
+}

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -1,4 +1,4 @@
-import { Chat, Message, Update } from "telegraf/types";
+import { Message } from "telegraf/types";
 import { useBot } from "../bot.ts";
 import { useConfig } from "../config.ts";
 import {
@@ -15,6 +15,8 @@ import {
   ForceReply,
 } from "telegraf/typings/core/types/typegram";
 import { log } from "../helpers.ts";
+import telegramifyMarkdown from "telegramify-markdown";
+import { splitBigMessage } from "../utils/text.ts";
 
 interface TelegramError extends Error {
   response?: {
@@ -22,37 +24,15 @@ interface TelegramError extends Error {
     description: string;
   };
 }
-type ForwardOrigin = {
+
+export type ForwardOrigin = {
   type: "user" | "hidden_user";
   sender_user?: User;
   sender_user_name?: string;
 };
-import telegramifyMarkdown from "telegramify-markdown";
 
 // let lastResponse: Message.TextMessage | undefined
 let forDelete: Message.TextMessage | undefined;
-
-export function splitBigMessage(text: string) {
-  const msgs: string[] = [];
-  const sizeLimit = 4096;
-  let msg = "";
-
-  for (const origLine of text.split("\n")) {
-    const line = origLine.trim();
-    if (!line) continue; // skip empty or whitespace-only lines
-    if (msg.length + line.length + 1 > sizeLimit) {
-      // +1 for the added '\n'
-      if (msg.trim()) msgs.push(msg);
-      msg = "";
-    }
-    msg += line + "\n";
-  }
-  if (msg.length > sizeLimit) {
-    msg = msg.slice(0, sizeLimit - 3) + "...";
-  }
-  if (msg.trim()) msgs.push(msg);
-  return msgs;
-}
 
 function sanitizeTelegramHtml(html: string): string {
   // Заменяем <p> и </p> на двойной перенос строки
@@ -68,7 +48,7 @@ function sanitizeTelegramHtml(html: string): string {
   return result.trim();
 }
 
-interface ExtraCtx {
+export interface ExtraCtx {
   noSendTelegram?: boolean;
   progressCallback?: (msg: string) => void;
 }
@@ -135,10 +115,7 @@ export async function sendTelegramMessage(
   if (params.parse_mode === "HTML") {
     processedText = sanitizeTelegramHtml(text);
   } else if (params.parse_mode === "MarkdownV2") {
-    // const replacedNewlines = text.replace(/\n/g, '#n');
-    // const ZWSP = '\u200B';
     processedText = telegramifyMarkdown(processedText, "keep");
-    // processedText = processedText.replace(/\\#n/g, `\n${ZWSP}`);
   } else if (params.parse_mode === "Markdown") {
     processedText = telegramifyMarkdown(text, "keep");
   }
@@ -162,13 +139,8 @@ export async function sendTelegramMessage(
           chatId: chat_id,
           logLevel: "warn",
         });
-        // Optionally: flag user in DB or take other action
         continue;
       }
-      // Fallback to failsafeParams for other errors
-      // Previous fallback code:
-      // const failsafeParams = { reply_markup: params.reply_markup };
-      // response = await useBot(chatConfig.bot_token).telegram.sendMessage(chat_id, msg, failsafeParams);
       const failsafeParams = {
         reply_markup: params.reply_markup as
           | InlineKeyboardMarkup
@@ -194,8 +166,8 @@ export async function sendTelegramMessage(
     if (response)
       setTimeout(async () => {
         await useBot(chatConfig?.bot_token).telegram.deleteMessage(
-          response.chat.id,
-          response.message_id,
+          response!.chat.id,
+          response!.message_id,
         );
       }, deleteAfter);
   }
@@ -213,11 +185,9 @@ export async function sendTelegramMessage(
     forDelete = response;
   }
 
-  // lastResponse = response
   return response;
 }
 
-// Check if the user is an admin
 export function isAdminUser(msg: Message.TextMessage): boolean {
   if (!msg.from?.username) return false;
   return (useConfig().adminUsers || []).includes(msg.from.username);
@@ -256,148 +226,6 @@ export function getFullName(msg: {
   }
 }
 
-function isAccessAllowed(chatConfig: ConfigChatType, ctxChat: Chat) {
-  const privateChat = ctxChat as Chat.PrivateChat;
-  const allowedUsers = [
-    ...(chatConfig.privateUsers ?? useConfig().privateUsers),
-    ...(useConfig().adminUsers ?? []),
-  ];
-  const username = privateChat.username || "without_username";
-  return allowedUsers.includes(username);
-}
-
-function getChatConfig(
-  ctxChat: Chat,
-  ctx: Context,
-): ConfigChatType | undefined {
-  // 1. by chat id
-  let chat =
-    useConfig().chats.find(
-      (c) => c.id == ctxChat?.id || c.ids?.includes(ctxChat?.id) || 0,
-    ) || ({} as ConfigChatType);
-
-  const defaultChat = useConfig().chats.find((c) => c.name === "default");
-
-  // 2. by bot_name
-  if (!chat.id) {
-    chat =
-      useConfig().chats.find((c) => c.bot_name === ctx.botInfo.username) ||
-      ({} as ConfigChatType);
-
-    // check access to private chat
-    if (chat.id && ctxChat?.type === "private") {
-      if (!isAccessAllowed(chat, ctxChat)) {
-        return;
-      }
-    }
-  }
-
-  if (!chat.id) {
-    // console.log("ctxChat:", ctxChat);
-    if (ctxChat?.type !== "private") {
-      const chatTitle = (ctxChat as Chat.TitleChat).title;
-      log({
-        msg: `This is ${ctxChat?.type} chat, not in whitelist: ${ctxChat.title}`,
-        chatId: ctxChat.id,
-        chatTitle,
-        logLevel: "warn",
-      });
-      return;
-    }
-
-    if (defaultChat) chat = defaultChat;
-
-    // 2. by username
-    if (ctxChat?.type === "private") {
-      // user chat, with username
-      const privateChat = ctxChat as Chat.PrivateChat;
-
-      // check access
-      if (!isAccessAllowed(chat, ctxChat)) {
-        return;
-      }
-
-      const userChat = useConfig().chats.find(
-        (c) => c.username === privateChat.username || "",
-      );
-      if (userChat) chat = userChat;
-    }
-  }
-
-  function mergeConfigParam<T extends Record<string, unknown>>(
-    name: keyof T,
-    from: Partial<T> | undefined,
-    to: T | undefined,
-  ) {
-    if (!from || !from[name] || !to) return;
-    to[name] = to[name]
-      ? ({
-          ...(from[name] as object),
-          ...(to[name] as object),
-        } as T[typeof name])
-      : from[name];
-  }
-
-  mergeConfigParam<{ completionParams: CompletionParamsType }>(
-    "completionParams",
-    useConfig() as Partial<{ completionParams: CompletionParamsType }>,
-    chat,
-  );
-
-  if (chat && defaultChat) {
-    chat = { ...defaultChat, ...chat };
-    mergeConfigParam<{ completionParams: CompletionParamsType }>(
-      "completionParams",
-      defaultChat,
-      chat,
-    );
-  }
-
-  return chat;
-}
-
-export function getActionUserMsg(ctx: Context): { user?: User; msg?: Message } {
-  // edited message
-  if (Object.prototype.hasOwnProperty.call(ctx, "update")) {
-    const updateQuery = ctx.update as Update.CallbackQueryUpdate;
-    const user = updateQuery.callback_query.from;
-    const msg = updateQuery.callback_query.message;
-    return { user, msg };
-  }
-  return {};
-}
-
-// return {chat, msg}
-export function getCtxChatMsg(ctx: Context): {
-  chat: ConfigChatType | undefined;
-  msg: Message.TextMessage | undefined;
-} {
-  let ctxChat: Chat | undefined;
-  let msg: Message.TextMessage | undefined;
-
-  // edited message
-  if (Object.prototype.hasOwnProperty.call(ctx, "update")) {
-    // console.log("ctx.update:", ctx.update);
-    const updateEdited = ctx.update as Update.EditedMessageUpdate; //{ edited_message: Message.TextMessage, chat: Chat };
-    const updateNew = ctx.update as Update.MessageUpdate;
-    msg = (updateEdited.edited_message ||
-      updateNew.message) as Message.TextMessage;
-    // console.log("msg:", msg);
-    ctxChat = msg?.chat;
-    // console.log('no message in ctx');
-    // return;
-  }
-
-  if (!ctxChat) {
-    console.log("no ctx chat detected");
-    return { chat: undefined, msg: undefined };
-  }
-
-  const chat = getChatConfig(ctxChat, ctx);
-
-  return { chat, msg };
-}
-
 export function getTelegramForwardedUser(
   msg: Message.TextMessage & { forward_origin?: ForwardOrigin },
   chatConfig: ConfigChatType,
@@ -416,7 +244,9 @@ export function getTelegramForwardedUser(
   const name =
     forwardOrigin.type === "hidden_user"
       ? forwardOrigin.sender_user_name
-      : `${forwardOrigin.sender_user?.first_name ?? ""} ${forwardOrigin.sender_user?.last_name ?? ""}`.trim();
+      : `${forwardOrigin.sender_user?.first_name ?? ""} ${
+          forwardOrigin.sender_user?.last_name ?? ""
+        }`.trim();
 
   return `${name}${username ? `, Telegram: @${username}` : ""}`;
 }

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,0 +1,20 @@
+export function splitBigMessage(text: string) {
+  const msgs: string[] = [];
+  const sizeLimit = 4096;
+  let msg = "";
+
+  for (const origLine of text.split("\n")) {
+    const line = origLine.trim();
+    if (!line) continue;
+    if (msg.length + line.length + 1 > sizeLimit) {
+      if (msg.trim()) msgs.push(msg);
+      msg = "";
+    }
+    msg += line + "\n";
+  }
+  if (msg.length > sizeLimit) {
+    msg = msg.slice(0, sizeLimit - 3) + "...";
+  }
+  if (msg.trim()) msgs.push(msg);
+  return msgs;
+}

--- a/tests/helpers/access.test.ts
+++ b/tests/helpers/access.test.ts
@@ -6,8 +6,11 @@ import { ConfigChatType } from "../../src/types";
 const mockGetCtxChatMsg = jest.fn();
 const mockSendTelegramMessage = jest.fn();
 
-jest.unstable_mockModule("../../src/helpers/telegram.ts", () => ({
+jest.unstable_mockModule("../../src/telegram/context.ts", () => ({
   getCtxChatMsg: mockGetCtxChatMsg,
+}));
+
+jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
   isAdminUser: () => false,
   sendTelegramMessage: mockSendTelegramMessage,
 }));

--- a/tests/helpers/handlersMention.test.ts
+++ b/tests/helpers/handlersMention.test.ts
@@ -5,13 +5,12 @@ import { Context, Message } from "telegraf/types";
 const mockSendTelegramMessage = jest.fn();
 const mockCheckAccessLevel = jest.fn();
 
-jest.unstable_mockModule("../../src/helpers/telegram.ts", () => ({
+jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
   __esModule: true,
   sendTelegramMessage: mockSendTelegramMessage,
   getFullName: jest.fn(),
   getTelegramForwardedUser: jest.fn(),
   isAdminUser: jest.fn(),
-  getCtxChatMsg: jest.fn(),
 }));
 
 jest.unstable_mockModule("../../src/handlers/access.ts", () => ({

--- a/tests/helpers/resolveChatButtons.test.ts
+++ b/tests/helpers/resolveChatButtons.test.ts
@@ -9,7 +9,7 @@ import {
 
 const mockSendTelegramMessage = jest.fn();
 
-jest.unstable_mockModule("../../src/helpers/telegram.ts", () => ({
+jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
   sendTelegramMessage: mockSendTelegramMessage,
 }));
 


### PR DESCRIPTION
## Summary
- move telegram send helpers into `src/telegram/`
- create `context.ts` for chat-context utils
- add text utilities module
- update imports and tests

## Testing
- `npm run format`
- `npm run test-full` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684b4cb6bc28832c9a3c0f21fa936d80