### PR TITLE
Fix Langfuse trace for tool calls

### DIFF
--- a/src/helpers/gpt/tools.ts
+++ b/src/helpers/gpt/tools.ts
@@ -327,7 +327,7 @@ export async function executeTools(
     }
 
     if (!chatConfig.chatParams?.confirmation) {
-      const { trace } = useLangfuse(msg);
+      const { trace } = useLangfuse(msg, chatConfig);
       let span;
       if (trace) {
         span = trace.span({

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -1,11 +1,7 @@
 import { Message } from "telegraf/types";
 import { useBot } from "../bot.ts";
 import { useConfig } from "../config.ts";
-import {
-  CompletionParamsType,
-  ConfigChatButtonType,
-  ConfigChatType,
-} from "../types.ts";
+import { ConfigChatButtonType, ConfigChatType } from "../types.ts";
 import { Context, Markup } from "telegraf";
 import { User } from "@telegraf/types/manage";
 import {


### PR DESCRIPTION
## Summary
- ensure tool calls use same Langfuse trace as llm-call
- remove unused import from `send.ts`

## Testing
- `npm run format`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_68515cfdfb20832ca0a38294462a1643