### PR TITLE
Add global Jest console mocks

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,7 @@ const config = {
   transformIgnorePatterns: [
     'node_modules/(?!(langfuse|@langfuse)/)',
   ],
+  setupFilesAfterEnv: ['<rootDir>/tests/setupTests.ts'],
   collectCoverage: true,
   coverageDirectory: 'coverage',
 };

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,5 +1,4 @@
 import { jest } from "@jest/globals";
-import { mockConsole } from "./testHelpers";
 
 // Mock the modules using jest.requireMock
 const mockExistsSync = jest.fn();
@@ -43,7 +42,6 @@ const { readConfig, writeConfig, generateConfig } = await import(
 );
 
 describe("readConfig", () => {
-  mockConsole();
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -81,8 +79,6 @@ describe("readConfig", () => {
 });
 
 describe("writeConfig", () => {
-  mockConsole();
-
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -127,7 +123,6 @@ describe("writeConfig", () => {
 });
 
 describe("readConfig agent_name", () => {
-  mockConsole();
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -182,7 +177,6 @@ describe("readConfig agent_name", () => {
 });
 
 describe("checkConfigSchema", () => {
-  mockConsole();
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/tests/helpers/access.test.ts
+++ b/tests/helpers/access.test.ts
@@ -1,5 +1,4 @@
 import { jest } from "@jest/globals";
-import { mockConsole } from "../testHelpers";
 import { Message } from "telegraf/types";
 import { ConfigChatType } from "../../src/types";
 
@@ -17,8 +16,6 @@ const { default: checkAccessLevel } = await import(
 );
 
 describe("checkAccessLevel", () => {
-  mockConsole();
-
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/tests/helpers/handlersMention.test.ts
+++ b/tests/helpers/handlersMention.test.ts
@@ -1,5 +1,4 @@
 import { jest } from "@jest/globals";
-import { mockConsole } from "../testHelpers";
 import { Context, Message } from "telegraf/types";
 
 const mockSendTelegramMessage = jest.fn();
@@ -46,8 +45,6 @@ function createCtx(message: Record<string, unknown>): Context {
 }
 
 describe("ignore unmentioned messages", () => {
-  mockConsole();
-
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/tests/helpers/resolveChatButtons.test.ts
+++ b/tests/helpers/resolveChatButtons.test.ts
@@ -1,5 +1,4 @@
 import { jest } from "@jest/globals";
-import { mockConsole } from "../testHelpers";
 import { Context, Message } from "telegraf/types";
 import {
   ConfigChatType,
@@ -18,8 +17,6 @@ const { default: resolveChatButtons } = await import(
 );
 
 describe("resolveChatButtons", () => {
-  mockConsole();
-
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,0 +1,24 @@
+// Jest exposes beforeEach and afterEach globally
+let jestObj: typeof import('@jest/globals').jest;
+
+const originalConsole = { ...console };
+
+beforeEach(async () => {
+  if (!jestObj) {
+    const mod = await import('@jest/globals');
+    jestObj = mod.jest;
+  }
+  console.log = jestObj.fn();
+  console.error = jestObj.fn();
+  console.warn = jestObj.fn();
+  console.info = jestObj.fn();
+});
+
+afterEach(() => {
+  console.log = originalConsole.log;
+  console.error = originalConsole.error;
+  console.warn = originalConsole.warn;
+  console.info = originalConsole.info;
+});
+
+export {};


### PR DESCRIPTION
## Summary
- add setupTests.ts with beforeEach/afterEach console mocking
- reference setup file in jest.config.js
- remove manual mockConsole calls from tests

## Testing
- `npm run test-full`

------
https://chatgpt.com/codex/tasks/task_e_684b4ddeaff4832cbb116fa4c7fe0635