### PR TITLE
Add delay for split telegram messages

### DIFF
--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -118,7 +118,10 @@ export async function sendTelegramMessage(
 
   const msgs = splitBigMessage(processedText);
 
-  for (const msg of msgs) {
+  for (const [index, msg] of msgs.entries()) {
+    if (index > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
     try {
       response = await useBot(chatConfig.bot_token).telegram.sendMessage(
         chat_id,


### PR DESCRIPTION
## Summary
- throttle sending of long messages split into chunks

## Testing
- `npm run test-full`

------
https://chatgpt.com/codex/tasks/task_e_685993a7a78c832ca42425b3bafa5e51