### PR TITLE
Fix name sanitization in buildMessages

### DIFF
--- a/src/helpers/gpt/messages.ts
+++ b/src/helpers/gpt/messages.ts
@@ -3,6 +3,10 @@ import { getEncoding, TiktokenEncoding } from "js-tiktoken";
 import { ChatToolType, ConfigChatType, ThreadStateType } from "../../types.ts";
 import { getToolsPrompts, getToolsSystemMessages } from "./tools.ts";
 
+function sanitizeName(name?: string) {
+  return name ? name.replace(/[\s<>|/]/g, "").slice(0, 64) : undefined;
+}
+
 export async function buildMessages(
   systemMessage: string,
   history: OpenAI.ChatCompletionMessageParam[],
@@ -21,7 +25,17 @@ export async function buildMessages(
     history.shift();
   }
 
-  messages.push(...history);
+  messages.push(
+    ...history.map((m) => {
+      const msg = { ...m } as OpenAI.ChatCompletionMessageParam & {
+        name?: string;
+      };
+      if (msg.name) {
+        msg.name = sanitizeName(msg.name);
+      }
+      return msg;
+    }),
+  );
 
   return messages;
 }

--- a/tests/helpers/buildMessages.test.ts
+++ b/tests/helpers/buildMessages.test.ts
@@ -17,4 +17,13 @@ describe("buildMessages", () => {
     expect(res[1].role).toBe("user");
     expect(res.length).toBeLessThanOrEqual(8); // limit + system
   });
+
+  it("sanitizes user name", async () => {
+    const history: OpenAI.ChatCompletionMessageParam[] = [
+      { role: "user", content: "hi", name: "John / Doe" },
+    ];
+
+    const res = await buildMessages("sys", history);
+    expect(res[1].name).toBe("JohnDoe");
+  });
 });

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,11 +1,11 @@
 // Jest exposes beforeEach and afterEach globally
-let jestObj: typeof import('@jest/globals').jest;
+let jestObj: typeof import("@jest/globals").jest;
 
 const originalConsole = { ...console };
 
 beforeEach(async () => {
   if (!jestObj) {
-    const mod = await import('@jest/globals');
+    const mod = await import("@jest/globals");
     jestObj = mod.jest;
   }
   console.log = jestObj.fn();


### PR DESCRIPTION
## Summary
- sanitize user name to avoid API errors
- test name sanitization in buildMessages
- apply formatting changes

## Testing
- `npm run test-full`

------
https://chatgpt.com/codex/tasks/task_e_685ba26ce7e4832c862ae985108a4ab5