### PR TITLE
Improve test coverage for telegram helpers

### DIFF
--- a/src/helpers/placeholders.ts
+++ b/src/helpers/placeholders.ts
@@ -47,7 +47,7 @@ export async function replaceToolPlaceholders(
   thread: import("../types").ThreadStateType,
   cacheTime = 0,
 ): Promise<string> {
-  const regex = /\{tool:([^\(]+)\(([^\)]*)\)}/g;
+  const regex = /{tool:([^()]+)\(([^)]*)\)}/g;
   const matches = [...text.matchAll(regex)];
   for (const match of matches) {
     const [, toolName, argsStr] = match;

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,4 +1,5 @@
-import { log } from "../src/helpers.ts";
+import { jest } from "@jest/globals";
+import { log, agentNameToId } from "../src/helpers.ts";
 
 describe("log", () => {
   let consoleOutput: string[] = [];
@@ -73,5 +74,20 @@ describe("log", () => {
         "[123] [Test Chat] [user] [testuser] Test message with details",
       ),
     );
+  });
+});
+
+describe("agentNameToId", () => {
+  it("generates stable positive ids", () => {
+    const id1 = agentNameToId("test");
+    const id2 = agentNameToId("test");
+    expect(id1).toBe(id2);
+    expect(id1).toBeGreaterThanOrEqual(0);
+  });
+
+  it("produces different ids for different names", () => {
+    const a = agentNameToId("a");
+    const b = agentNameToId("b");
+    expect(a).not.toBe(b);
   });
 });

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,4 +1,3 @@
-import { jest } from "@jest/globals";
 import { log, agentNameToId } from "../src/helpers.ts";
 
 describe("log", () => {

--- a/tests/helpers/history.test.ts
+++ b/tests/helpers/history.test.ts
@@ -1,0 +1,67 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Message } from "telegraf/types";
+import type { ConfigChatType, ThreadStateType } from "../../src/types";
+
+const threads: Record<number, ThreadStateType> = {};
+
+jest.unstable_mockModule("../../src/threads.ts", () => ({
+  useThreads: () => threads,
+}));
+
+jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
+  getFullName: () => "John Doe",
+}));
+
+const { addToHistory, forgetHistoryOnTimeout } = await import(
+  "../../src/helpers/history.ts"
+);
+
+describe("history helpers", () => {
+  beforeEach(() => {
+    for (const k of Object.keys(threads)) delete threads[Number(k)];
+  });
+
+  function createMsg(text: string, date = 0): Message.TextMessage {
+    return {
+      chat: { id: 1, type: "private" },
+      from: { id: 1, is_bot: false, first_name: "John" },
+      message_id: 1,
+      date,
+      text,
+    } as Message.TextMessage;
+  }
+
+  const baseChat: ConfigChatType = {
+    name: "chat",
+    completionParams: {},
+    chatParams: {},
+    toolParams: {},
+  } as ConfigChatType;
+
+  it("adds message with username", () => {
+    const msg = createMsg("hi");
+    addToHistory({ msg, showTelegramNames: true });
+    expect(threads[1].messages[0]).toEqual({
+      role: "user",
+      content: "John Doe:\nhi",
+      name: "John",
+    });
+    expect(threads[1].msgs[0]).toBe(msg);
+  });
+
+  it("handles timeout and forgets history", () => {
+    const oldMsg = createMsg("1", 0);
+    const recentMsg = createMsg("2", 10);
+    threads[1] = {
+      id: 1,
+      msgs: [oldMsg, recentMsg],
+      messages: [{ role: "user", content: "1" }],
+    } as ThreadStateType;
+    jest.spyOn(Date, "now").mockReturnValue((oldMsg.date + 11) * 1000);
+    const chat = { ...baseChat, chatParams: { forgetTimeout: 10 } };
+    const res = forgetHistoryOnTimeout(chat, recentMsg);
+    expect(res).toBe(true);
+    expect(threads[1].messages.length).toBe(1);
+    expect(threads[1].messages[0].content).toBe("2");
+  });
+});

--- a/tests/telegram/send.test.ts
+++ b/tests/telegram/send.test.ts
@@ -1,0 +1,112 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Message } from "telegraf/types";
+import type { ConfigChatType } from "../../src/types";
+
+const mockUseConfig = jest.fn();
+
+jest.unstable_mockModule("../../src/config.ts", () => ({
+  useConfig: () => mockUseConfig(),
+}));
+
+const { isAdminUser, buildButtonRows, getFullName, getTelegramForwardedUser } =
+  await import("../../src/telegram/send.ts");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseConfig.mockReturnValue({ adminUsers: ["admin"], privateUsers: [] });
+});
+
+describe("isAdminUser", () => {
+  it("detects admin user", () => {
+    const msg = {
+      from: { username: "admin" },
+    } as unknown as Message.TextMessage;
+    expect(isAdminUser(msg)).toBe(true);
+  });
+
+  it("returns false for non admin", () => {
+    const msg = {
+      from: { username: "user" },
+    } as unknown as Message.TextMessage;
+    expect(isAdminUser(msg)).toBe(false);
+  });
+
+  it("returns false when username missing", () => {
+    const msg = { from: {} } as unknown as Message.TextMessage;
+    expect(isAdminUser(msg)).toBe(false);
+  });
+});
+
+describe("buildButtonRows", () => {
+  it("groups buttons by row", () => {
+    const res = buildButtonRows([
+      { name: "A", prompt: "", row: 1 },
+      { name: "B", prompt: "", row: 2 },
+      { name: "C", prompt: "", row: 1 },
+    ]);
+    expect(res).toEqual([[{ text: "A" }, { text: "C" }], [{ text: "B" }]]);
+  });
+});
+
+describe("getFullName", () => {
+  it("uses hidden user name", () => {
+    const msg = {
+      forward_origin: { type: "hidden_user", sender_user_name: "Anon" },
+    } as unknown as Message.TextMessage;
+    expect(getFullName(msg)).toBe("Anon");
+  });
+
+  it("uses forwarded user name", () => {
+    const msg = {
+      forward_origin: {
+        type: "user",
+        sender_user: { first_name: "John", last_name: "Doe" },
+      },
+    } as unknown as Message.TextMessage;
+    expect(getFullName(msg)).toBe("John Doe");
+  });
+
+  it("uses from field", () => {
+    const msg = {
+      from: { first_name: "Jane", last_name: "Smith" },
+    } as unknown as Message.TextMessage;
+    expect(getFullName(msg)).toBe("Jane Smith");
+  });
+});
+
+describe("getTelegramForwardedUser", () => {
+  const baseChat = {
+    name: "chat",
+    completionParams: {},
+    chatParams: {},
+    toolParams: {},
+  } as ConfigChatType;
+
+  it("returns empty string when not forwarded", () => {
+    const msg = { text: "hi" } as unknown as Message.TextMessage;
+    expect(getTelegramForwardedUser(msg, baseChat)).toBe("");
+  });
+
+  it("formats forwarded user", () => {
+    const msg = {
+      forward_origin: {
+        type: "user",
+        sender_user: { first_name: "John", username: "john" },
+      },
+    } as unknown as Message.TextMessage;
+    expect(getTelegramForwardedUser(msg, baseChat)).toBe(
+      "John, Telegram: @john",
+    );
+  });
+
+  it("returns empty when user is private", () => {
+    const chat = { ...baseChat, privateUsers: ["john"] } as ConfigChatType;
+    const msg = {
+      forward_origin: {
+        type: "user",
+        sender_user: { first_name: "John", username: "john" },
+      },
+    } as unknown as Message.TextMessage;
+    expect(getTelegramForwardedUser(msg, chat)).toBe("");
+  });
+});

--- a/tests/utils/text.test.ts
+++ b/tests/utils/text.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "@jest/globals";
+import { splitBigMessage } from "../../src/utils/text.ts";
+
+describe("splitBigMessage", () => {
+  it("splits long text into multiple messages", () => {
+    const long1 = "a".repeat(4000);
+    const long2 = "b".repeat(200);
+    const res = splitBigMessage(`${long1}\n${long2}`);
+    expect(res.length).toBe(2);
+    expect(res[0]).toContain(long1);
+    expect(res[1]).toContain(long2);
+  });
+
+  it("truncates single oversized line", () => {
+    const line = "x".repeat(4100);
+    const [msg] = splitBigMessage(line);
+    expect(msg.length).toBe(4096);
+    expect(msg.endsWith("...")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for helper functions in `send.ts`
- test `splitBigMessage` util
- cover `agentNameToId` hashing helper

## Testing
- `npm run test-full`

------
https://chatgpt.com/codex/tasks/task_e_685d625b9058832ca8db0731d39f7a61