### PR TITLE
Improve test coverage

### DIFF
--- a/tests/configExtras.test.ts
+++ b/tests/configExtras.test.ts
@@ -1,4 +1,5 @@
 import { jest, describe, it, beforeEach, expect } from "@jest/globals";
+import type { OAuth2Client } from "google-auth-library";
 const mockLog = jest.fn();
 const mockWriteFile = jest.fn();
 const mockExistsSync = jest.fn().mockReturnValue(true);
@@ -102,9 +103,10 @@ describe("getGoogleButtons", () => {
       readGoogleSheet: jest.fn().mockResolvedValue(undefined),
     }));
     mod = await import("../src/config.ts");
+    const auth = {} as unknown as OAuth2Client;
     const res = await mod.getGoogleButtons(
       { sheetId: "id", sheetName: "s" },
-      {} as any,
+      auth,
     );
     expect(res).toBeUndefined();
   });
@@ -118,9 +120,10 @@ describe("getGoogleButtons", () => {
       ]),
     }));
     mod = await import("../src/config.ts");
+    const auth = {} as unknown as OAuth2Client;
     const res = await mod.getGoogleButtons(
       { sheetId: "id", sheetName: "s" },
-      {} as any,
+      auth,
     );
     expect(res).toEqual([
       { name: "btn", prompt: "pr", row: 1, waitMessage: "wait" },

--- a/tests/configExtras.test.ts
+++ b/tests/configExtras.test.ts
@@ -1,0 +1,129 @@
+import { jest, describe, it, beforeEach, expect } from "@jest/globals";
+const mockLog = jest.fn();
+const mockWriteFile = jest.fn();
+const mockExistsSync = jest.fn().mockReturnValue(true);
+const mockReadFileSync = jest.fn().mockReturnValue("");
+const mockWatchFile = jest.fn();
+
+jest.unstable_mockModule("../src/helpers.ts", () => ({
+  log: mockLog,
+}));
+
+jest.unstable_mockModule("fs", () => ({
+  __esModule: true,
+  default: {
+    writeFileSync: mockWriteFile,
+    existsSync: mockExistsSync,
+    readFileSync: mockReadFileSync,
+    watchFile: mockWatchFile,
+  },
+  writeFileSync: mockWriteFile,
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+  watchFile: mockWatchFile,
+}));
+
+let mod: typeof import("../src/config.ts");
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockLog.mockClear();
+  mockWriteFile.mockClear();
+  mod = await import("../src/config.ts");
+});
+
+describe("validateConfig", () => {
+  it("returns false and logs when tokens missing", () => {
+    const cfg = mod.generateConfig();
+    const valid = mod.validateConfig(cfg);
+    expect(valid).toBe(false);
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg: expect.stringContaining("No auth.bot_token"),
+      }),
+    );
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg: expect.stringContaining("No auth.chatgpt_api_key"),
+      }),
+    );
+  });
+
+  it("returns true when tokens provided", () => {
+    const cfg = mod.generateConfig();
+    cfg.auth.bot_token = "token";
+    cfg.auth.chatgpt_api_key = "key";
+    const valid = mod.validateConfig(cfg);
+    expect(valid).toBe(true);
+    expect(mockLog).not.toHaveBeenCalled();
+  });
+});
+
+describe("generatePrivateChatConfig", () => {
+  it("creates private chat config", () => {
+    const cfg = mod.generatePrivateChatConfig("alice");
+    expect(cfg).toEqual({
+      name: "Private alice",
+      username: "alice",
+      toolParams: {},
+      chatParams: {},
+    });
+  });
+});
+
+describe("logConfigChanges", () => {
+  it("writes diff when configs differ", () => {
+    const oldCfg = mod.generateConfig();
+    const newCfg = mod.generateConfig();
+    newCfg.bot_name = "new";
+    mod.logConfigChanges(oldCfg, newCfg);
+    expect(mockLog).toHaveBeenCalled();
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      "data/last-config-change.diff",
+      expect.any(String),
+    );
+  });
+
+  it("does nothing when configs equal", () => {
+    const cfg = mod.generateConfig();
+    mod.logConfigChanges(cfg, cfg);
+    expect(mockLog).not.toHaveBeenCalled();
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("getGoogleButtons", () => {
+  beforeEach(async () => {
+    jest.resetModules();
+  });
+
+  it("returns undefined when sheet fails", async () => {
+    jest.unstable_mockModule("../src/helpers/readGoogleSheet", () => ({
+      readGoogleSheet: jest.fn().mockResolvedValue(undefined),
+    }));
+    mod = await import("../src/config.ts");
+    const res = await mod.getGoogleButtons(
+      { sheetId: "id", sheetName: "s" },
+      {} as any,
+    );
+    expect(res).toBeUndefined();
+  });
+
+  it("parses rows to buttons", async () => {
+    jest.unstable_mockModule("../src/helpers/readGoogleSheet", () => ({
+      readGoogleSheet: jest.fn().mockResolvedValue([
+        ["name", "prompt"],
+        ["btn", "pr", 1, "wait"],
+        ["#comment", "foo"],
+      ]),
+    }));
+    mod = await import("../src/config.ts");
+    const res = await mod.getGoogleButtons(
+      { sheetId: "id", sheetName: "s" },
+      {} as any,
+    );
+    expect(res).toEqual([
+      { name: "btn", prompt: "pr", row: 1, waitMessage: "wait" },
+    ]);
+  });
+});

--- a/tests/helpers/getTokensCount.test.ts
+++ b/tests/helpers/getTokensCount.test.ts
@@ -1,0 +1,40 @@
+import { jest, describe, it, beforeEach, expect } from "@jest/globals";
+
+const mockGetEncoding = jest.fn();
+const fakeEncoding = { encode: (txt: string) => txt.split(" ") };
+
+jest.unstable_mockModule("js-tiktoken", () => ({
+  getEncoding: (name: string) => mockGetEncoding(name),
+}));
+
+let getTokensCount: typeof import("../../src/helpers/gpt/messages.ts").getTokensCount;
+
+const baseConfig: { completionParams: { model: string } } = {
+  completionParams: { model: "gpt-3.5-turbo" },
+};
+
+describe("getTokensCount", () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    mockGetEncoding.mockReturnValue(fakeEncoding);
+    ({ getTokensCount } = await import("../../src/helpers/gpt/messages.ts"));
+  });
+
+  it("uses cl100k_base encoding by default", () => {
+    getTokensCount(baseConfig, "a b c");
+    expect(mockGetEncoding).toHaveBeenCalledWith("cl100k_base");
+  });
+
+  it("uses o200k_base for 4o models", () => {
+    const cfg: { completionParams: { model: string } } = {
+      completionParams: { model: "gpt-4o" },
+    };
+    getTokensCount(cfg, "a b c");
+    expect(mockGetEncoding).toHaveBeenCalledWith("o200k_base");
+  });
+
+  it("counts tokens using encoding", () => {
+    const count = getTokensCount(baseConfig, "a b c");
+    expect(count).toBe(3);
+  });
+});

--- a/tests/helpers/gptTools.test.ts
+++ b/tests/helpers/gptTools.test.ts
@@ -1,0 +1,188 @@
+import { jest, describe, it, beforeEach, expect } from "@jest/globals";
+import type { Message } from "telegraf/types";
+import type {
+  ConfigChatType,
+  ChatToolType,
+  ThreadStateType,
+} from "../../src/types";
+import type { ChatCompletionMessageToolCall } from "openai/resources/chat/completions";
+
+// Mocks
+const mockUseTools = jest.fn();
+const mockIsAdminUser = jest.fn();
+const mockUseConfig = jest.fn();
+const mockUseThreads = jest.fn();
+const mockSendTelegramMessage = jest.fn();
+const mockLog = jest.fn();
+const mockSendToHttp = jest.fn();
+const mockPublish = jest.fn();
+const mockUseLangfuse = jest.fn().mockReturnValue({ trace: null });
+const mockRequestGptAnswer = jest.fn();
+
+jest.unstable_mockModule("../../src/helpers/useTools.ts", () => ({
+  default: (...args: unknown[]) => mockUseTools(...args),
+}));
+
+jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
+  sendTelegramMessage: (...args: unknown[]) => mockSendTelegramMessage(...args),
+  getFullName: () => "User",
+  isAdminUser: (...args: unknown[]) => mockIsAdminUser(...args),
+}));
+
+jest.unstable_mockModule("../../src/config.ts", () => ({
+  useConfig: () => mockUseConfig(),
+}));
+
+jest.unstable_mockModule("../../src/threads.ts", () => ({
+  useThreads: () => mockUseThreads(),
+}));
+
+jest.unstable_mockModule("../../src/helpers.ts", () => ({
+  log: (...args: unknown[]) => mockLog(...args),
+  sendToHttp: (...args: unknown[]) => mockSendToHttp(...args),
+}));
+
+jest.unstable_mockModule("../../src/mqtt.ts", () => ({
+  publishMqttProgress: (...args: unknown[]) => mockPublish(...args),
+}));
+
+jest.unstable_mockModule("../../src/helpers/useLangfuse.ts", () => ({
+  default: () => mockUseLangfuse(),
+}));
+
+jest.unstable_mockModule("../../src/helpers/gpt/llm.ts", () => ({
+  requestGptAnswer: (...args: unknown[]) => mockRequestGptAnswer(...args),
+}));
+
+let tools: typeof import("../../src/helpers/gpt/tools.ts");
+
+const baseMsg: Message.TextMessage = {
+  message_id: 1,
+  text: "hi",
+  chat: { id: 1, type: "private", title: "chat" },
+  from: { username: "user" },
+} as Message.TextMessage;
+
+const baseConfig: ConfigChatType = {
+  name: "chat",
+  agent_name: "agent",
+  completionParams: {},
+  chatParams: {},
+  toolParams: {},
+};
+
+beforeEach(async () => {
+  jest.resetModules();
+  jest.clearAllMocks();
+  mockUseConfig.mockReturnValue({ chats: [baseConfig] });
+  mockUseThreads.mockReturnValue({ 1: { id: 1, msgs: [], messages: [] } });
+  tools = await import("../../src/helpers/gpt/tools.ts");
+});
+
+describe("resolveChatTools", () => {
+  it("adds change_chat_settings for private chat", async () => {
+    mockUseTools.mockResolvedValue([]);
+    mockIsAdminUser.mockReturnValue(false);
+    const cfg: ConfigChatType = { ...baseConfig, tools: [] };
+    const result = await tools.resolveChatTools(baseMsg, cfg);
+    expect(cfg.tools).toContain("change_chat_settings");
+    expect(result).toEqual([]);
+  });
+
+  it("includes global and agent tools", async () => {
+    const globalTool = { name: "foo", module: { call: jest.fn() } };
+    mockUseTools.mockResolvedValue([globalTool]);
+    mockIsAdminUser.mockReturnValue(false);
+    const cfg: ConfigChatType = {
+      ...baseConfig,
+      tools: ["foo", { agent_name: "agent", name: "agent_tool" }],
+    };
+    const res = await tools.resolveChatTools(baseMsg, cfg);
+    expect(res[0]).toBe(globalTool);
+    expect(res[1].name).toBe("agent_tool");
+  });
+
+  it("skips agent tool for other users", async () => {
+    const globalTool = { name: "foo", module: { call: jest.fn() } };
+    mockUseTools.mockResolvedValue([globalTool]);
+    mockIsAdminUser.mockReturnValue(false);
+    mockUseConfig.mockReturnValue({
+      chats: [{ ...baseConfig, privateUsers: ["other"] }],
+    });
+    const cfg: ConfigChatType = {
+      ...baseConfig,
+      tools: ["foo", { agent_name: "agent", name: "agent_tool" }],
+    };
+    const res = await tools.resolveChatTools(baseMsg, cfg);
+    expect(res).toEqual([globalTool]);
+  });
+});
+
+describe("getToolsPrompts", () => {
+  it("collects prompts from chat tools", async () => {
+    const chatTools: ChatToolType[] = [
+      {
+        name: "a",
+        module: {
+          call: () => ({ prompt_append: () => "p1" }),
+        },
+      },
+      {
+        name: "b",
+        module: {
+          call: () => ({}),
+        },
+      },
+      {
+        name: "c",
+        module: {
+          call: () => ({ prompt_append: () => "p3" }),
+        },
+      },
+    ];
+    const thread: ThreadStateType = { id: 1, msgs: [], messages: [] };
+    const prompts = await tools.getToolsPrompts(chatTools, baseConfig, thread);
+    expect(prompts).toEqual(["p1", "p3"]);
+  });
+});
+
+describe("getToolsSystemMessages", () => {
+  it("collects system messages from chat tools", async () => {
+    const chatTools: ChatToolType[] = [
+      {
+        name: "a",
+        module: {
+          call: () => ({ systemMessage: () => "s1" }),
+        },
+      },
+      {
+        name: "b",
+        module: {
+          call: () => ({}),
+        },
+      },
+    ];
+    const thread: ThreadStateType = { id: 1, msgs: [], messages: [] };
+    const msgs = await tools.getToolsSystemMessages(
+      chatTools,
+      baseConfig,
+      thread,
+    );
+    expect(msgs).toEqual(["s1"]);
+  });
+});
+
+describe("executeTools", () => {
+  it("returns not found when tool missing", async () => {
+    const toolCalls: ChatCompletionMessageToolCall[] = [
+      {
+        id: "1",
+        type: "function",
+        function: { name: "missing", arguments: "{}" },
+      },
+    ];
+    const cfg: ConfigChatType = { ...baseConfig, chatParams: {} };
+    const res = await tools.executeTools(toolCalls, [], cfg, baseMsg);
+    expect(res).toEqual([{ content: "Tool not found: missing" }]);
+  });
+});

--- a/tests/helpers/readGoogleSheet.test.ts
+++ b/tests/helpers/readGoogleSheet.test.ts
@@ -1,0 +1,53 @@
+import { jest, describe, it, beforeEach, expect } from "@jest/globals";
+import type { OAuth2Client } from "google-auth-library";
+
+const mockSheetsGet = jest.fn();
+const mockValuesGet = jest.fn();
+
+jest.unstable_mockModule("googleapis", () => ({
+  google: {
+    sheets: () => ({
+      spreadsheets: {
+        get: mockSheetsGet,
+        values: { get: mockValuesGet },
+      },
+    }),
+  },
+}));
+
+let readGoogleSheetToRows: typeof import("../../src/helpers/readGoogleSheet.ts").default;
+
+const auth = {} as unknown as OAuth2Client;
+
+describe("readGoogleSheetToRows", () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    mockSheetsGet.mockResolvedValue({
+      data: { sheets: [{ properties: { title: "Sheet1" } }] },
+    });
+    mockValuesGet.mockResolvedValue({
+      data: {
+        values: [
+          ["Name", "Age"],
+          ["Alice", "30"],
+        ],
+      },
+    });
+    ({ default: readGoogleSheetToRows } = await import(
+      "../../src/helpers/readGoogleSheet.ts"
+    ));
+  });
+
+  it("returns empty array when auth missing", async () => {
+    const mod = await import("../../src/helpers/readGoogleSheet.ts");
+    const res = await mod.default("id", undefined as unknown as OAuth2Client);
+    expect(res).toEqual([]);
+  });
+
+  it("converts rows to objects", async () => {
+    const rows = await readGoogleSheetToRows("sheet", auth);
+    expect(mockSheetsGet).toHaveBeenCalled();
+    expect(mockValuesGet).toHaveBeenCalled();
+    expect(rows).toEqual([{ Name: "Alice", Age: "30" }]);
+  });
+});

--- a/tests/helpers/useApi.test.ts
+++ b/tests/helpers/useApi.test.ts
@@ -1,0 +1,49 @@
+import { jest, describe, it, beforeEach, expect } from "@jest/globals";
+
+const mockUseConfig = jest.fn();
+const mockOpenAI = jest.fn(function (
+  this: Record<string, unknown>,
+  opts: Record<string, unknown>,
+) {
+  Object.assign(this, { opts });
+});
+
+jest.unstable_mockModule("../../src/config.ts", () => ({
+  useConfig: () => mockUseConfig(),
+}));
+
+jest.unstable_mockModule("openai", () => ({
+  default: mockOpenAI,
+  OpenAI: mockOpenAI,
+}));
+
+let useApi: (model?: string) => unknown;
+
+describe("useApi", () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    mockOpenAI.mockClear();
+    mockUseConfig.mockReturnValue({
+      auth: { chatgpt_api_key: "key", proxy_url: "" },
+      local_models: [{ name: "local", url: "http://local" }],
+    });
+    const mod = await import("../../src/helpers/useApi.ts");
+    useApi = mod.useApi;
+  });
+
+  it("creates and caches default api", () => {
+    const api1 = useApi();
+    const api2 = useApi();
+    expect(mockOpenAI).toHaveBeenCalledTimes(1);
+    expect(api1).toBe(api2);
+    expect(api1.opts.apiKey).toBe("key");
+  });
+
+  it("creates separate instance for local model", () => {
+    const api1 = useApi("local");
+    const api2 = useApi("local");
+    expect(mockOpenAI).toHaveBeenCalledTimes(1);
+    expect(api1).toBe(api2);
+    expect(api1.opts.baseURL).toBe("http://local/v1");
+  });
+});

--- a/tests/helpers/useLangfuse.test.ts
+++ b/tests/helpers/useLangfuse.test.ts
@@ -1,0 +1,63 @@
+import { jest, describe, it, beforeEach, expect } from "@jest/globals";
+import type { Message } from "telegraf/types";
+
+const mockTrace = jest.fn();
+class MockLangfuse {
+  options: unknown;
+  constructor(opts: Record<string, unknown>) {
+    this.options = opts;
+  }
+  trace(params: Record<string, unknown>) {
+    mockTrace(params);
+    return { name: params.name as string };
+  }
+}
+
+const mockUseConfig = jest.fn();
+
+jest.unstable_mockModule("../../src/config.ts", () => ({
+  useConfig: () => mockUseConfig(),
+}));
+
+jest.unstable_mockModule("langfuse", () => ({
+  Langfuse: MockLangfuse,
+  LangfuseTraceClient: class {},
+}));
+
+let useLangfuse: typeof import("../../src/helpers/useLangfuse.ts").default;
+
+const baseMsg: Message.TextMessage = {
+  message_id: 1,
+  text: "hi",
+  chat: { id: 1, type: "private", title: "" },
+  from: { username: "user" },
+} as Message.TextMessage;
+
+describe("useLangfuse", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("returns null when config missing", async () => {
+    mockUseConfig.mockReturnValue({ langfuse: {}, bot_name: "bot" });
+    ({ default: useLangfuse } = await import(
+      "../../src/helpers/useLangfuse.ts"
+    ));
+    const res = useLangfuse(baseMsg);
+    expect(res).toEqual({ langfuse: null, trace: null });
+  });
+
+  it("creates trace when config present", async () => {
+    mockUseConfig.mockReturnValue({
+      langfuse: { secretKey: "s", publicKey: "p", baseUrl: "url" },
+      bot_name: "bot",
+    });
+    ({ default: useLangfuse } = await import(
+      "../../src/helpers/useLangfuse.ts"
+    ));
+    const res = useLangfuse(baseMsg);
+    expect(res.langfuse).toBeInstanceOf(MockLangfuse);
+    expect(res.trace).toEqual({ name: "user private bot  1" });
+    expect(mockTrace).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for API helper
- add tests for Langfuse helper
- add tests for Google sheets helper
- test token counting logic

## Testing
- `npm run test-full`

------
https://chatgpt.com/codex/tasks/task_e_685dac61b188832cbdf119bbfa063cfd