### PR TITLE
Improve coverage for llm and send modules

### DIFF
--- a/tests/helpers/llm.test.ts
+++ b/tests/helpers/llm.test.ts
@@ -1,0 +1,140 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Message } from "telegraf/types";
+import type {
+  ConfigChatType,
+  GptContextType,
+  ToolResponse,
+} from "../../src/types";
+
+const mockExecuteTools = jest.fn();
+const mockAddToHistory = jest.fn();
+const mockForgetHistory = jest.fn();
+
+jest.unstable_mockModule("../../src/helpers/gpt/tools.ts", () => ({
+  executeTools: (...args: unknown[]) => mockExecuteTools(...args),
+  resolveChatTools: jest.fn(),
+  getToolsPrompts: jest.fn(),
+  getToolsSystemMessages: jest.fn(),
+}));
+
+jest.unstable_mockModule("../../src/helpers/history.ts", () => ({
+  addToHistory: (...args: unknown[]) => mockAddToHistory(...args),
+  forgetHistory: (...args: unknown[]) => mockForgetHistory(...args),
+}));
+
+jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
+  sendTelegramMessage: jest.fn(),
+  getTelegramForwardedUser: jest.fn(),
+}));
+
+let handleModelAnswer: typeof import("../../src/helpers/gpt/llm.ts").handleModelAnswer;
+let processToolResults: typeof import("../../src/helpers/gpt/llm.ts").processToolResults;
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockExecuteTools.mockReset();
+  mockAddToHistory.mockReset();
+  mockForgetHistory.mockReset();
+  const mod = await import("../../src/helpers/gpt/llm.ts");
+  handleModelAnswer = mod.handleModelAnswer;
+  processToolResults = mod.processToolResults;
+});
+
+describe("handleModelAnswer", () => {
+  const msg: Message.TextMessage = {
+    chat: { id: 1, type: "private" },
+    message_id: 1,
+    text: "hi",
+  } as Message.TextMessage;
+  const chatConfig: ConfigChatType = {
+    name: "chat",
+    completionParams: {},
+    chatParams: {},
+    toolParams: {},
+  } as ConfigChatType;
+  const gptContext: GptContextType = {
+    thread: { id: 1, messages: [], msgs: [], completionParams: {} },
+    messages: [],
+    systemMessage: "",
+    chatTools: [],
+    prompts: [],
+    tools: [],
+  } as GptContextType;
+
+  it("parses tool_call tags and executes tools", async () => {
+    const json = JSON.stringify({
+      id: "1",
+      type: "function",
+      function: { name: "tool", arguments: "{}" },
+    });
+    const res = {
+      choices: [{ message: { content: `<tool_call>${json}</tool_call>` } }],
+    } as any;
+    mockExecuteTools.mockResolvedValue(undefined);
+    await handleModelAnswer({
+      msg,
+      res,
+      chatConfig,
+      expressRes: undefined,
+      gptContext,
+    });
+    expect(mockExecuteTools).toHaveBeenCalledWith(
+      [JSON.parse(json)],
+      gptContext.chatTools,
+      chatConfig,
+      msg,
+      undefined,
+      undefined,
+    );
+    expect(mockAddToHistory).toHaveBeenCalled();
+  });
+});
+
+describe("processToolResults", () => {
+  const msg: Message.TextMessage = {
+    chat: { id: 1, type: "private" },
+    message_id: 1,
+    text: "hi",
+  } as Message.TextMessage;
+  const chatConfig: ConfigChatType = {
+    name: "chat",
+    completionParams: {},
+    chatParams: {},
+    toolParams: {},
+  } as ConfigChatType;
+  const baseContext: GptContextType = {
+    thread: { id: 1, messages: [], msgs: [], completionParams: {} },
+    messages: [],
+    systemMessage: "",
+    chatTools: [],
+    prompts: [],
+    tools: [],
+  } as GptContextType;
+
+  it("handles forget tool and clears history", async () => {
+    const tool_res: ToolResponse[] = [{ content: "done" }];
+    const messageAgent = {
+      role: "assistant",
+      content: "",
+      tool_calls: [
+        {
+          id: "1",
+          type: "function",
+          function: { name: "forget", arguments: '{"message":"bye"}' },
+        },
+      ],
+    } as any;
+    const res = await processToolResults({
+      tool_res,
+      messageAgent,
+      chatConfig,
+      msg,
+      expressRes: undefined,
+      gptContext: { ...baseContext },
+      level: 1,
+    });
+    expect(res.content).toBe("bye");
+    expect(mockForgetHistory).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/telegram/sendMessageExtra.test.ts
+++ b/tests/telegram/sendMessageExtra.test.ts
@@ -1,0 +1,82 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { ConfigChatType } from "../../src/types";
+
+const mockSendMessage = jest.fn();
+const mockDeleteMessage = jest.fn();
+const mockUseBot = jest.fn(() => ({
+  telegram: { sendMessage: mockSendMessage, deleteMessage: mockDeleteMessage },
+}));
+
+jest.unstable_mockModule("../../src/bot.ts", () => ({
+  useBot: (...args: unknown[]) => mockUseBot(...args),
+}));
+
+jest.unstable_mockModule("../../src/helpers.ts", () => ({
+  log: jest.fn(),
+}));
+
+// mock splitBigMessage so we control number of parts
+const mockSplit = jest.fn();
+jest.unstable_mockModule("../../src/utils/text.ts", () => ({
+  splitBigMessage: (...args: unknown[]) => mockSplit(...args),
+}));
+
+let sendTelegramMessage: typeof import("../../src/telegram/send.ts").sendTelegramMessage;
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockSendMessage.mockReset();
+  mockDeleteMessage.mockReset();
+  mockSplit.mockReset();
+  const mod = await import("../../src/telegram/send.ts");
+  sendTelegramMessage = mod.sendTelegramMessage;
+});
+
+describe("sendTelegramMessage", () => {
+  const chatConfig: ConfigChatType = {
+    name: "chat",
+    completionParams: {},
+    chatParams: {},
+    toolParams: {},
+    bot_token: "token",
+  } as ConfigChatType;
+
+  it("sanitizes HTML and sets parse_mode", async () => {
+    mockSplit.mockImplementation((t) => [t]);
+    await sendTelegramMessage(
+      1,
+      "<p>Hello&nbsp;world</p><br>Next",
+      {},
+      undefined,
+      chatConfig,
+    );
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      1,
+      "Hello world\n\nNext",
+      expect.objectContaining({ parse_mode: "HTML" }),
+    );
+  });
+
+  it("handles think tag", async () => {
+    mockSplit.mockImplementation((t) => [t]);
+    await sendTelegramMessage(
+      1,
+      "<think>foo</think> result",
+      {},
+      undefined,
+      chatConfig,
+    );
+    expect(mockSendMessage).toHaveBeenCalledTimes(2);
+    const texts = mockSendMessage.mock.calls.map((c) => c[1]);
+    expect(texts.some((t) => t.includes("`think:`") && t.includes("foo"))).toBe(
+      true,
+    );
+    expect(texts.some((t) => t.includes("result"))).toBe(true);
+  });
+
+  it("splits long messages", async () => {
+    mockSplit.mockReturnValue(["part1", "part2"]);
+    await sendTelegramMessage(1, "long", {}, undefined, chatConfig);
+    expect(mockSendMessage).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for sendTelegramMessage covering HTML sanitization, think tag and message splitting
- add tests for llm.handleModelAnswer and processToolResults paths

## Testing
- `npm run test-full`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_685dc466b10c832cae08a585523a79fe