### PR TITLE
Increase handler test coverage

### DIFF
--- a/tests/handlers/isMentioned.test.ts
+++ b/tests/handlers/isMentioned.test.ts
@@ -1,0 +1,89 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Message } from "telegraf/types";
+import type { ConfigChatType } from "../../src/types";
+
+const mockUseConfig = jest.fn();
+
+jest.unstable_mockModule("../../src/config.ts", () => ({
+  useConfig: () => mockUseConfig(),
+}));
+
+const { isMentioned } = await import("../../src/handlers/access.ts");
+
+function createMsg(opts: Partial<Message.TextMessage>): Message.TextMessage {
+  return {
+    chat: { id: 1, type: "group" },
+    from: { username: "user" },
+    message_id: 1,
+    date: 0,
+    text: "hi",
+    ...opts,
+  } as Message.TextMessage;
+}
+
+const baseChat: ConfigChatType = {
+  name: "chat",
+  prefix: "!",
+  completionParams: {},
+  chatParams: {},
+  toolParams: {},
+} as ConfigChatType;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseConfig.mockReturnValue({ bot_name: "mybot" });
+});
+
+describe("isMentioned", () => {
+  it("returns true when no prefix", () => {
+    const chat = { ...baseChat, prefix: undefined } as ConfigChatType;
+    const msg = createMsg({ text: "hello" });
+    expect(isMentioned(msg, chat)).toBe(true);
+  });
+
+  it("detects prefix", () => {
+    const msg = createMsg({ text: "!hello" });
+    expect(isMentioned(msg, baseChat)).toBe(true);
+  });
+
+  it("detects mention", () => {
+    const msg = createMsg({ text: "hi @mybot" });
+    expect(isMentioned(msg, baseChat)).toBe(true);
+  });
+
+  it("detects reply to bot", () => {
+    const msg = createMsg({
+      reply_to_message: {
+        chat: { id: 1, type: "group" },
+        from: { username: "mybot" },
+        message_id: 2,
+        date: 0,
+        text: "bot",
+      } as Message.TextMessage,
+    });
+    expect(isMentioned(msg, baseChat)).toBe(true);
+  });
+
+  it("returns false when reply to other user", () => {
+    const msg = createMsg({
+      reply_to_message: {
+        chat: { id: 1, type: "group" },
+        from: { username: "other" },
+        message_id: 2,
+        date: 0,
+        text: "hi",
+      } as Message.TextMessage,
+    });
+    expect(isMentioned(msg, baseChat)).toBe(false);
+  });
+
+  it("ignores prefix in private chat", () => {
+    const msg = createMsg({ chat: { id: 2, type: "private" }, text: "hello" });
+    expect(isMentioned(msg, baseChat)).toBe(true);
+  });
+
+  it("returns false for group without mention", () => {
+    const msg = createMsg({ text: "hello" });
+    expect(isMentioned(msg, baseChat)).toBe(false);
+  });
+});

--- a/tests/handlers/onUnsupported.test.ts
+++ b/tests/handlers/onUnsupported.test.ts
@@ -1,0 +1,68 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Context, Message } from "telegraf/types";
+
+const mockCheckAccessLevel = jest.fn();
+const mockSendTelegramMessage = jest.fn();
+
+jest.unstable_mockModule("../../src/handlers/access.ts", () => ({
+  __esModule: true,
+  default: mockCheckAccessLevel,
+}));
+
+jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
+  sendTelegramMessage: mockSendTelegramMessage,
+}));
+
+const { default: onUnsupported } = await import(
+  "../../src/handlers/onUnsupported.ts"
+);
+
+function createCtx(message: Record<string, unknown>): Context {
+  return {
+    message,
+    update: { message },
+    chat: message.chat,
+    persistentChatAction: async (_: string, fn: () => Promise<void>) => {
+      await fn();
+    },
+  } as unknown as Context;
+}
+
+describe("onUnsupported", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("handles known type", async () => {
+    const msg = {
+      chat: { id: 1, type: "group" },
+      from: { username: "u" },
+      video: { file_id: "v" },
+    } as unknown as Message.VideoMessage;
+    mockCheckAccessLevel.mockResolvedValue({ msg });
+    const ctx = createCtx(msg);
+    await onUnsupported(ctx);
+    expect(mockSendTelegramMessage).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("видео"),
+      {},
+      ctx,
+    );
+  });
+
+  it("handles unknown type", async () => {
+    const msg = {
+      chat: { id: 1, type: "group" },
+      from: { username: "u" },
+    } as unknown as Message.TextMessage;
+    mockCheckAccessLevel.mockResolvedValue({ msg });
+    const ctx = createCtx(msg);
+    await onUnsupported(ctx);
+    expect(mockSendTelegramMessage).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("неизвестного"),
+      {},
+      ctx,
+    );
+  });
+});

--- a/tests/handlers/photoAudioEarly.test.ts
+++ b/tests/handlers/photoAudioEarly.test.ts
@@ -1,0 +1,79 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Context, Message } from "telegraf/types";
+
+const mockCheckAccessLevel = jest.fn();
+const mockSendTelegramMessage = jest.fn();
+const mockUseConfig = jest.fn();
+
+jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
+  sendTelegramMessage: mockSendTelegramMessage,
+  getFullName: jest.fn(),
+  getTelegramForwardedUser: jest.fn(),
+  isAdminUser: jest.fn(),
+  buildButtonRows: jest.fn(),
+}));
+
+jest.unstable_mockModule("../../src/handlers/access.ts", () => ({
+  __esModule: true,
+  default: mockCheckAccessLevel,
+}));
+
+jest.unstable_mockModule("../../src/config.ts", () => ({
+  useConfig: () => mockUseConfig(),
+  readConfig: jest.fn(),
+  syncButtons: jest.fn(),
+}));
+
+const { default: onPhoto } = await import("../../src/handlers/onPhoto.ts");
+const { default: onAudio } = await import("../../src/handlers/onAudio.ts");
+
+function createCtx(message: Record<string, unknown>): Context {
+  return {
+    message,
+    update: { message },
+    chat: message.chat,
+    persistentChatAction: async (_: string, fn: () => Promise<void>) => {
+      await fn();
+    },
+  } as unknown as Context;
+}
+
+describe("onPhoto/onAudio early branches", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("photo unsupported", async () => {
+    const msg = {
+      chat: { id: 1, type: "group" },
+      from: { username: "u" },
+      photo: [{ file_id: "1" }],
+    } as unknown as Message.PhotoMessage;
+    mockCheckAccessLevel.mockResolvedValue({ msg, chat: {} });
+    mockUseConfig.mockReturnValue({});
+    const ctx = createCtx(msg);
+    await onPhoto(ctx);
+    expect(mockSendTelegramMessage).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("обработка изображений"),
+    );
+  });
+
+  it("audio unsupported", async () => {
+    const msg = {
+      chat: { id: 1, type: "group" },
+      from: { username: "u" },
+      voice: { file_id: "v" },
+    } as unknown as Message.VoiceMessage;
+    mockCheckAccessLevel.mockResolvedValue({ msg });
+    mockUseConfig.mockReturnValue({});
+    const ctx = createCtx(msg);
+    await onAudio(ctx);
+    expect(mockSendTelegramMessage).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("Аудио не поддерживается"),
+      undefined,
+      ctx,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `isMentioned` logic
- add tests for unsupported media handler
- test early branches in photo/audio handlers

## Testing
- `npm run test-full`

------
https://chatgpt.com/codex/tasks/task_e_685deb7cc754832c8a997074a833bced