### PR TITLE
Add Docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,9 @@ WORKDIR /app
 COPY --from=builder /build/node_modules ./node_modules
 COPY . .
 
+# healthcheck script
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+  CMD node healthcheck.js
+
 # default command
 CMD ["npm", "run", "start"]

--- a/healthcheck.js
+++ b/healthcheck.js
@@ -1,0 +1,36 @@
+import http from 'http';
+
+function request(path) {
+  return new Promise((resolve) => {
+    const req = http.get({ host: 'localhost', port: process.env.PORT || 7586, path }, (res) => {
+      let data = '';
+      res.on('data', (c) => (data += c));
+      res.on('end', () => resolve({ statusCode: res.statusCode, data }));
+    });
+    req.on('error', () => resolve({ statusCode: 0, data: '' }));
+  });
+}
+
+(async () => {
+  const ping = await request('/ping');
+  if (ping.statusCode !== 200) {
+    console.error('Ping failed');
+    process.exit(1);
+  }
+  const health = await request('/health');
+  if (health.statusCode !== 200) {
+    console.error('Health endpoint unavailable');
+    process.exit(1);
+  }
+  try {
+    const { botsRunning, mqttConnected } = JSON.parse(health.data);
+    if (!botsRunning || !mqttConnected) {
+      console.error('Bots or MQTT unhealthy');
+      process.exit(1);
+    }
+  } catch {
+    console.error('Invalid health response');
+    process.exit(1);
+  }
+  process.exit(0);
+})();

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -12,3 +12,7 @@ export function useBot(bot_token?: string) {
   }
   return bots[bot_token];
 }
+
+export function getBots() {
+  return bots;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
 import { initCommands } from "./commands.ts";
 import { log } from "./helpers.ts";
 import express from "express";
-import { useBot } from "./bot";
+import { useBot, getBots } from "./bot";
 import onTextMessage from "./handlers/onTextMessage.ts";
 import onPhoto from "./handlers/onPhoto.ts";
 import onAudio from "./handlers/onAudio.ts";
@@ -22,7 +22,7 @@ import {
   agentPostHandler,
   toolPostHandler,
 } from "./httpHandlers.ts";
-import { useMqtt } from "./mqtt.ts";
+import { useMqtt, isMqttConnected } from "./mqtt.ts";
 
 process.on("uncaughtException", (error, source) => {
   console.log("Uncaught Exception:", error);
@@ -158,6 +158,15 @@ function initHttp() {
   // Add /ping test route
   app.get("/ping", (req, res) => {
     res.send("pong");
+  });
+
+  app.get("/health", (_req, res) => {
+    const bots = getBots();
+    const botsRunning = Object.values(bots).every((bot) => {
+      const polling = (bot as any).polling;
+      return polling && !polling.abortController.signal.aborted;
+    });
+    res.json({ botsRunning, mqttConnected: isMqttConnected() });
   });
 
   // Add route handler to create a virtual message and call onMessage

--- a/src/mqtt.ts
+++ b/src/mqtt.ts
@@ -5,6 +5,7 @@ import { log } from "./helpers.ts";
 
 const MQTT_LOG_PATH = "data/mqtt.log";
 let client: mqtt.MqttClient | undefined;
+let connected = false;
 
 export function useMqtt() {
   if (client) return client;
@@ -18,10 +19,12 @@ export function useMqtt() {
   });
   client.on("connect", () => {
     log({ msg: "mqtt connected", logPath: MQTT_LOG_PATH });
+    connected = true;
     client?.subscribe(`${cfg.base}/+`);
   });
   client.on("offline", () => {
     log({ msg: "mqtt offline", logPath: MQTT_LOG_PATH });
+    connected = false;
   });
   client.on("message", async (topic, message) => {
     if (!client) return;
@@ -50,4 +53,8 @@ export function publishMqttProgress(msg: string, agent?: string) {
   if (!cfg) return;
   if (!agent) return;
   client?.publish(`${cfg.base}/${agent}/progress`, msg);
+}
+
+export function isMqttConnected() {
+  return connected;
 }


### PR DESCRIPTION
## Summary
- add docker HEALTHCHECK
- track mqtt connectivity and export helper
- expose bots list and add /health endpoint
- healthcheck script verifies bots, mqtt and /ping

## Testing
- `npm run format`
- `npm run test-full`

------
https://chatgpt.com/codex/tasks/task_e_685e6fbe8184832cbaf333671845dfed