### PR TITLE
Add unit tests for bot, MCP and MQTT modules

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -12,6 +12,19 @@ import { log } from "./helpers.ts";
 // Store active MCP clients by model key
 const clients: Record<string, Client> = {};
 
+export const __test = {
+  /** Reset cached clients - used in tests */
+  resetClients() {
+    for (const key of Object.keys(clients)) {
+      delete clients[key];
+    }
+  },
+  /** Manually set a client for a model - used in tests */
+  setClient(model: string, client: Client) {
+    clients[model] = client;
+  },
+};
+
 type McpTool = {
   name: string;
   description: string;
@@ -137,7 +150,7 @@ function initSseMcp(serverUrl: string, model: string, client: Client) {
 /**
  * Connect to an MCP server with the given configuration
  */
-async function connectMcp(
+export async function connectMcp(
   model: string,
   cfg: McpToolConfig,
   clients: Record<string, Client>,

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -1,0 +1,49 @@
+import { jest, describe, it, beforeEach, expect } from "@jest/globals";
+
+const mockStop = jest.fn();
+const TelegrafMock = jest.fn().mockImplementation(() => ({ stop: mockStop }));
+const mockUseConfig = jest.fn();
+
+jest.unstable_mockModule("../src/config.ts", () => ({
+  useConfig: () => mockUseConfig(),
+}));
+
+jest.unstable_mockModule("telegraf", () => ({
+  Telegraf: TelegrafMock,
+}));
+
+let useBot: typeof import("../src/bot.ts").useBot;
+
+beforeEach(async () => {
+  jest.resetModules();
+  jest.clearAllMocks();
+  ({ useBot } = await import("../src/bot.ts"));
+});
+
+describe("useBot", () => {
+  it("creates bot with config token and caches instance", () => {
+    mockUseConfig.mockReturnValue({ auth: { bot_token: "token1" } });
+    const onceSpy = jest
+      .spyOn(process, "once")
+      .mockImplementation(() => process);
+
+    const first = useBot();
+    const second = useBot();
+
+    expect(first).toBe(second);
+    expect(TelegrafMock).toHaveBeenCalledTimes(1);
+    expect(TelegrafMock).toHaveBeenCalledWith("token1");
+    expect(onceSpy).toHaveBeenCalledWith("SIGINT", expect.any(Function));
+    expect(onceSpy).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
+    onceSpy.mockRestore();
+  });
+
+  it("uses provided token when passed", () => {
+    mockUseConfig.mockReturnValue({ auth: { bot_token: "token1" } });
+    const bot = useBot("custom");
+    const again = useBot("custom");
+    expect(bot).toBe(again);
+    expect(TelegrafMock).toHaveBeenCalledTimes(1);
+    expect(TelegrafMock).toHaveBeenCalledWith("custom");
+  });
+});

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -1,0 +1,52 @@
+import { jest, describe, it, beforeEach, expect } from "@jest/globals";
+
+let callMcp: typeof import("../src/mcp.ts").callMcp;
+let __test: typeof import("../src/mcp.ts").__test;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ callMcp, __test } = await import("../src/mcp.ts"));
+  __test.resetClients();
+});
+
+describe("callMcp", () => {
+  it("returns message when client missing", async () => {
+    const res = await callMcp("model", "tool", "{}");
+    expect(res).toEqual({ content: "MCP client not initialized: model" });
+  });
+
+  it("calls tool and returns string result", async () => {
+    const client = {
+      callTool: jest.fn().mockResolvedValue({ content: "ok" }),
+    } as unknown as {
+      callTool: jest.Mock<Promise<{ content: string }>, [unknown]>;
+    };
+    __test.setClient("m1", client);
+    const res = await callMcp("m1", "foo", "{}");
+    expect(client.callTool).toHaveBeenCalledWith({
+      name: "foo",
+      arguments: {},
+    });
+    expect(res).toEqual({ content: "ok" });
+  });
+
+  it("stringifies non string result", async () => {
+    const client = {
+      callTool: jest.fn().mockResolvedValue({ content: { a: 1 } }),
+    } as unknown as {
+      callTool: jest.Mock<Promise<{ content: unknown }>, [unknown]>;
+    };
+    __test.setClient("m2", client);
+    const res = await callMcp("m2", "foo", "{}");
+    expect(res).toEqual({ content: JSON.stringify({ a: 1 }) });
+  });
+
+  it("handles errors", async () => {
+    const client = {
+      callTool: jest.fn().mockRejectedValue(new Error("bad")),
+    } as unknown as { callTool: jest.Mock<Promise<never>, [unknown]> };
+    __test.setClient("m3", client);
+    const res = await callMcp("m3", "foo", "{}");
+    expect(res).toEqual({ content: "MCP call error: bad" });
+  });
+});

--- a/tests/mqtt.test.ts
+++ b/tests/mqtt.test.ts
@@ -1,0 +1,93 @@
+import { jest, describe, it, beforeEach, expect } from "@jest/globals";
+
+const handlers: Record<string, (...args: unknown[]) => unknown> = {};
+const mqttClient = {
+  on: (event: string, fn: (...args: unknown[]) => unknown) => {
+    handlers[event] = fn;
+  },
+  subscribe: jest.fn(),
+  publish: jest.fn(),
+};
+
+const mockConnect = jest.fn(() => mqttClient);
+const mockUseConfig = jest.fn();
+const mockRunAgent = jest.fn();
+const mockLog = jest.fn();
+
+jest.unstable_mockModule("mqtt", () => ({
+  default: { connect: (...args: unknown[]) => mockConnect(...args) },
+}));
+
+jest.unstable_mockModule("../src/config.ts", () => ({
+  useConfig: () => mockUseConfig(),
+}));
+
+jest.unstable_mockModule("../src/agent-runner.ts", () => ({
+  runAgent: (...args: unknown[]) => mockRunAgent(...args),
+}));
+
+jest.unstable_mockModule("../src/helpers.ts", () => ({
+  log: (...args: unknown[]) => mockLog(...args),
+}));
+
+let useMqtt: typeof import("../src/mqtt.ts").useMqtt;
+let publishMqttProgress: typeof import("../src/mqtt.ts").publishMqttProgress;
+
+beforeEach(async () => {
+  jest.resetModules();
+  jest.clearAllMocks();
+  for (const key of Object.keys(handlers)) delete handlers[key];
+  ({ useMqtt, publishMqttProgress } = await import("../src/mqtt.ts"));
+});
+
+describe("useMqtt", () => {
+  it("returns undefined when config missing", () => {
+    mockUseConfig.mockReturnValue({});
+    expect(useMqtt()).toBeUndefined();
+  });
+
+  it("connects and handles events", async () => {
+    mockUseConfig.mockReturnValue({ mqtt: { base: "base" } });
+    const client1 = useMqtt();
+    const client2 = useMqtt();
+    expect(client1).toBe(client2);
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+
+    handlers.connect();
+    expect(mockLog).toHaveBeenCalledWith({
+      msg: "mqtt connected",
+      logPath: "data/mqtt.log",
+    });
+    expect(mqttClient.subscribe).toHaveBeenCalledWith("base/+");
+
+    handlers.offline();
+    expect(mockLog).toHaveBeenCalledWith({
+      msg: "mqtt offline",
+      logPath: "data/mqtt.log",
+    });
+
+    mockRunAgent.mockResolvedValue("answer");
+    await handlers.message("base/agent", Buffer.from("hi"));
+    expect(mockRunAgent).toHaveBeenCalledWith(
+      "agent",
+      "hi",
+      expect.any(Function),
+    );
+    expect(mqttClient.publish).toHaveBeenCalledWith(
+      "base/agent/answer",
+      "answer",
+    );
+  });
+});
+
+describe("publishMqttProgress", () => {
+  it("publishes progress when agent and config present", () => {
+    mockUseConfig.mockReturnValue({ mqtt: { base: "base" } });
+    useMqtt();
+    publishMqttProgress("step", "agent");
+    expect(mqttClient.publish).toHaveBeenCalledWith(
+      "base/agent/progress",
+      "step",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- improve `mcp.ts` to export helpers for testing
- add unit tests for `useBot`
- add unit tests for MCP client calls
- add unit tests for MQTT integration

## Testing
- `npm run test-full`

------
https://chatgpt.com/codex/tasks/task_e_685e7ed51854832c9bd000bdca1be180