### PR TITLE
Add vision helper tests

### DIFF
--- a/tests/helpers/useTools.test.ts
+++ b/tests/helpers/useTools.test.ts
@@ -9,7 +9,7 @@ const mockCallMcp = jest.fn();
 
 jest.unstable_mockModule("fs", () => ({
   __esModule: true,
-  ...jest.requireActual("fs") as object,
+  ...(jest.requireActual("fs") as object),
   readdirSync: mockReaddirSync,
 }));
 
@@ -38,7 +38,7 @@ const barPath = path.resolve("src/tools/bar.ts");
 beforeAll(() => {
   fs.writeFileSync(
     fooPath,
-    "export function call() { return { content: 'foo' }; }"
+    "export function call() { return { content: 'foo' }; }",
   );
   fs.writeFileSync(barPath, "export const notCall = true;\n");
 });
@@ -79,27 +79,30 @@ describe("initTools", () => {
 
   it("adds MCP tools from initMcp", async () => {
     mockReadConfig.mockReturnValue({ mcpServers: { m1: {} } });
-    
+
     // Create a properly typed mock tool
     const mockTools: Array<{
       name: string;
       description: string;
       properties: Record<string, unknown>;
       model: string;
-    }> = [
-      { name: "mcp", description: "d", properties: {}, model: "m1" },
-    ];
-    
+    }> = [{ name: "mcp", description: "d", properties: {}, model: "m1" }];
+
     // Type the mock implementation
-    (mockInitMcp as jest.Mock).mockImplementation(() => Promise.resolve(mockTools));
-    
+    (mockInitMcp as jest.Mock).mockImplementation(() =>
+      Promise.resolve(mockTools),
+    );
+
     const tools = await initTools();
     expect(tools).toHaveLength(2);
     const mcpTool = tools.find((t) => t.name === "mcp");
     expect(mcpTool).toBeDefined();
     if (!mcpTool) return;
-    
-    const instance = mcpTool.module.call({} as unknown as ConfigChatType, {} as unknown as ThreadStateType);
+
+    const instance = mcpTool.module.call(
+      {} as unknown as ConfigChatType,
+      {} as unknown as ThreadStateType,
+    );
     await instance.functions.get("foo")("{}");
     expect(mockCallMcp).toHaveBeenCalledWith("m1", "foo", "{}");
   });

--- a/tests/helpers/vision.test.ts
+++ b/tests/helpers/vision.test.ts
@@ -1,0 +1,79 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Message } from "telegraf/types";
+import type { ConfigChatType } from "../../src/types";
+
+const mockGetFileLink = jest.fn();
+const mockUseBot = jest.fn(() => ({
+  telegram: { getFileLink: mockGetFileLink },
+}));
+const mockLlCall = jest.fn();
+const mockUseConfig = jest.fn();
+
+jest.unstable_mockModule("../../src/bot.ts", () => ({
+  useBot: (...args: unknown[]) => mockUseBot(...args),
+}));
+
+jest.unstable_mockModule("../../src/helpers/gpt.ts", () => ({
+  llmCall: (...args: unknown[]) => mockLlCall(...args),
+}));
+
+jest.unstable_mockModule("../../src/config.ts", () => ({
+  useConfig: () => mockUseConfig(),
+}));
+
+let vision: typeof import("../../src/helpers/vision.ts");
+
+beforeEach(async () => {
+  jest.resetModules();
+  jest.clearAllMocks();
+  mockUseConfig.mockReturnValue({});
+  vision = await import("../../src/helpers/vision.ts");
+});
+
+function createMsg(caption?: string): Message.PhotoMessage {
+  return {
+    chat: { id: 1, type: "private" },
+    photo: [{ file_id: "f1" }],
+    caption,
+  } as unknown as Message.PhotoMessage;
+}
+
+describe("recognizeImageText", () => {
+  it("returns empty string when model missing", async () => {
+    const msg = createMsg();
+    const res = await vision.recognizeImageText(msg, {} as ConfigChatType);
+    expect(res).toBe("");
+    expect(mockGetFileLink).toHaveBeenCalledWith("f1");
+    expect(mockLlCall).not.toHaveBeenCalled();
+  });
+
+  it("calls llmCall and returns trimmed result", async () => {
+    mockUseConfig.mockReturnValue({ vision: { model: "m" } });
+    mockGetFileLink.mockResolvedValue("http://file");
+    mockLlCall.mockResolvedValue({
+      res: { choices: [{ message: { content: " ok " } }] },
+    });
+    const msg = createMsg("cap");
+    const chat = {} as ConfigChatType;
+    const res = await vision.recognizeImageText(msg, chat);
+    expect(mockGetFileLink).toHaveBeenCalledWith("f1");
+    expect(mockLlCall).toHaveBeenCalledWith({
+      generationName: "llm-vision",
+      apiParams: expect.objectContaining({
+        model: "m",
+      }),
+      msg: msg as unknown as Message.TextMessage,
+      chatConfig: chat,
+    });
+    expect(res).toBe("ok");
+  });
+
+  it("returns empty string on error", async () => {
+    mockUseConfig.mockReturnValue({ vision: { model: "m" } });
+    mockGetFileLink.mockResolvedValue("http://file");
+    mockLlCall.mockRejectedValue(new Error("bad"));
+    const msg = createMsg();
+    const res = await vision.recognizeImageText(msg, {} as ConfigChatType);
+    expect(res).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- test vision.ts helper
- update formatted tests

## Testing
- `npm run test-full`
- `npm run coverage-info`


------
https://chatgpt.com/codex/tasks/task_e_685eaad075e0832cbf9706c6d2b8466f