### PR TITLE
Increase handler coverage

### DIFF
--- a/src/handlers/onAudio.ts
+++ b/src/handlers/onAudio.ts
@@ -31,7 +31,7 @@ type WhisperResponse = {
   segments?: (WhisperSegment | WhisperSegmentArray)[];
 };
 
-async function processAudio(
+export async function processAudio(
   ctx: Context & { secondTry?: boolean },
   voice: { file_id: string },
   chatId: number,

--- a/src/handlers/onTextMessage.ts
+++ b/src/handlers/onTextMessage.ts
@@ -92,7 +92,7 @@ export default async function onTextMessage(
   });
 }
 
-async function answerToMessage(
+export async function answerToMessage(
   ctx: Context & { secondTry?: boolean },
   msg: Message.TextMessage,
   chat: ConfigChatType,

--- a/tests/handlers/onAudioProcess.test.ts
+++ b/tests/handlers/onAudioProcess.test.ts
@@ -1,0 +1,86 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Context, Message } from "telegraf/types";
+
+const mockConvertToMp3 = jest.fn();
+const mockSendAudioWhisper = jest.fn();
+const mockSendTelegramMessage = jest.fn();
+const mockOnTextMessage = jest.fn();
+
+jest.unstable_mockModule("../../src/helpers/stt.ts", () => ({
+  convertToMp3: (...args: unknown[]) => mockConvertToMp3(...args),
+  sendAudioWhisper: (...args: unknown[]) => mockSendAudioWhisper(...args),
+}));
+
+jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
+  sendTelegramMessage: (...args: unknown[]) => mockSendTelegramMessage(...args),
+  getFullName: jest.fn(),
+  getTelegramForwardedUser: jest.fn(),
+  isAdminUser: jest.fn(),
+  buildButtonRows: jest.fn(),
+}));
+
+jest.unstable_mockModule("../../src/handlers/onTextMessage.ts", () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockOnTextMessage(...args),
+}));
+
+import fs from "fs";
+
+let processAudio: typeof import("../../src/handlers/onAudio.ts").processAudio;
+
+beforeAll(async () => {
+  processAudio = (await import("../../src/handlers/onAudio.ts")).processAudio;
+});
+
+function createCtx(): Context {
+  return {
+    telegram: {
+      getFileLink: jest.fn().mockResolvedValue({ href: "http://file" }),
+    },
+    persistentChatAction: async (_: string, fn: () => Promise<void>) => {
+      await fn();
+    },
+    message: {} as Message,
+    update: { message: {} } as unknown as { message: Message },
+  } as unknown as Context;
+}
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    arrayBuffer: async () => Buffer.from("data"),
+  }) as unknown as typeof fetch;
+  jest.spyOn(fs.promises, "writeFile").mockResolvedValue();
+  jest.spyOn(fs, "existsSync").mockReturnValue(true);
+  jest.spyOn(fs, "unlinkSync").mockImplementation(() => {});
+  mockConvertToMp3.mockResolvedValue("file.mp3");
+});
+
+describe("processAudio", () => {
+  it("processes text and forwards", async () => {
+    mockSendAudioWhisper.mockResolvedValue({ text: "hello" });
+    const ctx = createCtx();
+    await processAudio(ctx as Context, { file_id: "f" }, 1);
+    expect(mockSendTelegramMessage).toHaveBeenCalledWith(
+      1,
+      "hello",
+      undefined,
+      ctx,
+    );
+    expect(mockOnTextMessage).toHaveBeenCalled();
+  });
+
+  it("handles whisper error", async () => {
+    mockSendAudioWhisper.mockResolvedValue({ error: "bad" });
+    const ctx = createCtx();
+    await processAudio(ctx as Context, { file_id: "f" }, 1);
+    expect(mockSendTelegramMessage).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("Ошибка распознавания: bad"),
+      undefined,
+      ctx,
+    );
+    expect(mockOnTextMessage).not.toHaveBeenCalled();
+  });
+});

--- a/tests/handlers/onPhotoMain.test.ts
+++ b/tests/handlers/onPhotoMain.test.ts
@@ -1,0 +1,75 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Context, Message } from "telegraf/types";
+import type { ConfigChatType } from "../../src/types";
+
+const mockCheckAccessLevel = jest.fn();
+const mockRecognizeImageText = jest.fn();
+const mockUseConfig = jest.fn();
+const mockSendTelegramMessage = jest.fn();
+const mockOnTextMessage = jest.fn();
+
+jest.unstable_mockModule("../../src/handlers/access.ts", () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockCheckAccessLevel(...args),
+}));
+
+jest.unstable_mockModule("../../src/helpers/vision.ts", () => ({
+  recognizeImageText: (...args: unknown[]) => mockRecognizeImageText(...args),
+}));
+
+jest.unstable_mockModule("../../src/config.ts", () => ({
+  useConfig: () => mockUseConfig(),
+}));
+
+jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
+  sendTelegramMessage: (...args: unknown[]) => mockSendTelegramMessage(...args),
+}));
+
+jest.unstable_mockModule("../../src/handlers/onTextMessage.ts", () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockOnTextMessage(...args),
+}));
+
+let onPhoto: typeof import("../../src/handlers/onPhoto.ts").default;
+
+function createCtx(message: Record<string, unknown>): Context {
+  return {
+    message,
+    update: { message },
+    persistentChatAction: async (_: string, fn: () => Promise<void>) => {
+      await fn();
+    },
+  } as unknown as Context;
+}
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  jest.resetModules();
+  onPhoto = (await import("../../src/handlers/onPhoto.ts")).default;
+});
+
+describe("onPhoto main flow", () => {
+  it("recognizes text and forwards", async () => {
+    const msg = {
+      chat: { id: 1, type: "private", title: "t" },
+      photo: [{ file_id: "f" }],
+      caption: "cap",
+    } as Message.PhotoMessage;
+    const chat: ConfigChatType = {
+      name: "c",
+      completionParams: {},
+      chatParams: {},
+      toolParams: {},
+    } as ConfigChatType;
+    mockCheckAccessLevel.mockResolvedValue({ msg, chat });
+    mockUseConfig.mockReturnValue({ vision: { model: "m" } });
+    mockRecognizeImageText.mockResolvedValue("ocr");
+    const ctx = createCtx(msg);
+    await onPhoto(ctx);
+    expect(mockRecognizeImageText).toHaveBeenCalledWith(msg, chat);
+    expect(mockOnTextMessage).toHaveBeenCalled();
+    const calledCtx = mockOnTextMessage.mock.calls[0][0];
+    expect(calledCtx.message.text).toBe("cap\nocr");
+    expect(mockSendTelegramMessage).not.toHaveBeenCalled();
+  });
+});

--- a/tests/handlers/onTextMessageAnswer.test.ts
+++ b/tests/handlers/onTextMessageAnswer.test.ts
@@ -1,0 +1,131 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Context, Message } from "telegraf/types";
+import type { ConfigChatType } from "../../src/types";
+
+const threads: Record<
+  number,
+  {
+    id: number;
+    msgs: Message[];
+    messages: Message[];
+    completionParams: Record<string, unknown>;
+  }
+> = {
+  1: { id: 1, msgs: [], messages: [], completionParams: {} },
+};
+
+const mockEnsureAuth = jest.fn();
+const mockAddOauthToThread = jest.fn();
+const mockSyncButtons = jest.fn();
+const mockRequestGptAnswer = jest.fn();
+const mockSendTelegramMessage = jest.fn();
+const mockUseConfig = jest.fn();
+
+jest.unstable_mockModule("../../src/helpers/google.ts", () => ({
+  ensureAuth: (...args: unknown[]) => mockEnsureAuth(...args),
+  addOauthToThread: (...args: unknown[]) => mockAddOauthToThread(...args),
+}));
+
+jest.unstable_mockModule("../../src/config.ts", () => ({
+  useConfig: () => mockUseConfig(),
+  syncButtons: (...args: unknown[]) => mockSyncButtons(...args),
+}));
+
+jest.unstable_mockModule("../../src/helpers/gpt.ts", () => ({
+  requestGptAnswer: (...args: unknown[]) => mockRequestGptAnswer(...args),
+}));
+
+jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
+  sendTelegramMessage: (...args: unknown[]) => mockSendTelegramMessage(...args),
+  getFullName: jest.fn(),
+  getTelegramForwardedUser: jest.fn(),
+  isAdminUser: jest.fn(),
+  buildButtonRows: jest.fn(),
+}));
+
+jest.unstable_mockModule("../../src/threads.ts", () => ({
+  useThreads: () => threads,
+}));
+
+let handlers: typeof import("../../src/handlers/onTextMessage.ts");
+
+function createCtx(
+  message: Record<string, unknown>,
+): Context & { secondTry?: boolean } {
+  return {
+    message,
+    update: { message },
+    persistentChatAction: async (_: string, fn: () => Promise<void>) => {
+      await fn();
+    },
+  } as unknown as Context & { secondTry?: boolean };
+}
+
+const baseChat: ConfigChatType = {
+  name: "chat",
+  completionParams: {},
+  chatParams: {},
+  toolParams: {},
+} as ConfigChatType;
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  jest.resetModules();
+  handlers = await import("../../src/handlers/onTextMessage.ts");
+});
+
+describe("answerToMessage", () => {
+  it("handles sync buttons", async () => {
+    mockUseConfig.mockReturnValue({
+      auth: { oauth_google: { client_id: "id" } },
+    });
+    mockEnsureAuth.mockResolvedValue("auth");
+    mockSyncButtons.mockResolvedValue([{ name: "b" }]);
+    mockSendTelegramMessage.mockResolvedValue({
+      chat: { id: 1 },
+    } as unknown as Message.TextMessage);
+    const msg = {
+      chat: { id: 1, title: "t" },
+      from: { id: 1 },
+      text: "sync",
+    } as Message.TextMessage;
+    const ctx = createCtx(msg);
+    const chat = { ...baseChat, buttonsSync: true };
+    const res = await handlers.answerToMessage(ctx, msg, chat, {});
+    expect(mockSyncButtons).toHaveBeenCalled();
+    expect(mockSendTelegramMessage).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("Готово"),
+      expect.anything(),
+      ctx,
+      chat,
+    );
+    expect(res).toBeDefined();
+  });
+
+  it("sends gpt answer and stores message", async () => {
+    mockUseConfig.mockReturnValue({ auth: {} });
+    mockRequestGptAnswer.mockResolvedValue({ content: "hi" });
+    mockSendTelegramMessage.mockResolvedValue({
+      chat: { id: 1 },
+    } as unknown as Message.TextMessage);
+    const msg = {
+      chat: { id: 1, title: "t" },
+      from: { id: 1 },
+      text: "hello",
+    } as Message.TextMessage;
+    const ctx = createCtx(msg);
+    const chat = { ...baseChat, buttons: [{ name: "b" }] };
+    const res = await handlers.answerToMessage(ctx, msg, chat, {});
+    expect(mockRequestGptAnswer).toHaveBeenCalledWith(msg, chat, ctx);
+    expect(mockSendTelegramMessage).toHaveBeenCalledWith(
+      1,
+      "hi",
+      expect.anything(),
+      ctx,
+      chat,
+    );
+    expect(threads[1].msgs.length).toBe(1);
+    expect(res).toBeDefined();
+  });
+});

--- a/tests/handlers/onTextMessageOuter.test.ts
+++ b/tests/handlers/onTextMessageOuter.test.ts
@@ -1,0 +1,80 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Context, Message } from "telegraf/types";
+
+const threads: Record<
+  number,
+  {
+    id: number;
+    msgs: Message[];
+    messages: Message[];
+    completionParams: Record<string, unknown>;
+  }
+> = {
+  1: { id: 1, msgs: [], messages: [], completionParams: {} },
+};
+
+const mockCheckAccessLevel = jest.fn();
+const mockAddToHistory = jest.fn();
+const mockResolveChatButtons = jest.fn();
+
+jest.unstable_mockModule("../../src/handlers/access.ts", () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockCheckAccessLevel(...args),
+}));
+
+jest.unstable_mockModule("../../src/helpers/history.ts", () => ({
+  addToHistory: (...args: unknown[]) => mockAddToHistory(...args),
+  forgetHistoryOnTimeout: jest.fn(),
+  forgetHistory: jest.fn(),
+}));
+
+jest.unstable_mockModule("../../src/handlers/resolveChatButtons.ts", () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockResolveChatButtons(...args),
+}));
+
+jest.unstable_mockModule("../../src/threads.ts", () => ({
+  useThreads: () => threads,
+}));
+
+let onTextMessage: (ctx: Context & { secondTry?: boolean }) => Promise<void>;
+
+function createCtx(
+  message: Record<string, unknown>,
+): Context & { secondTry?: boolean } {
+  return {
+    message,
+    update: { message },
+    persistentChatAction: async (_: string, fn: () => Promise<void>) => {
+      await fn();
+    },
+  } as unknown as Context & { secondTry?: boolean };
+}
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  jest.resetModules();
+  onTextMessage = (await import("../../src/handlers/onTextMessage.ts")).default;
+});
+
+describe("onTextMessage outer", () => {
+  it("returns early when access denied", async () => {
+    mockCheckAccessLevel.mockResolvedValue(false);
+    const ctx = createCtx({} as Message.TextMessage);
+    await onTextMessage(ctx);
+    expect(mockAddToHistory).not.toHaveBeenCalled();
+  });
+
+  it("handles button response", async () => {
+    const msg = { chat: { id: 1 }, text: "hi" } as Message.TextMessage;
+    mockCheckAccessLevel.mockResolvedValue({
+      msg,
+      chat: { completionParams: {} },
+    });
+    mockResolveChatButtons.mockResolvedValue("ok");
+    const ctx = createCtx(msg);
+    const res = await onTextMessage(ctx);
+    expect(res).toBe("ok");
+    expect(mockAddToHistory).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- export internal functions for testing
- add tests for onTextMessage answer logic
- add tests for onTextMessage outer flow
- add tests for audio and photo handlers

## Testing
- `npm run test-full`
- `npm run coverage-info`


------
https://chatgpt.com/codex/tasks/task_e_685ec2e15648832c9231079fbf7afb2a