### PR TITLE
Add tests for httpHandlers and mcp

### DIFF
--- a/tests/connectMcp.test.ts
+++ b/tests/connectMcp.test.ts
@@ -1,0 +1,109 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+
+const mockConnect = jest.fn();
+
+class MockClient {
+  connect = mockConnect;
+  setNotificationHandler = jest.fn();
+  request = jest.fn().mockResolvedValue({ resources: [] });
+  constructor(public opts: unknown) {}
+}
+
+const mockStdio = jest.fn();
+const mockHttp = jest.fn();
+const mockLog = jest.fn();
+
+jest.unstable_mockModule("@modelcontextprotocol/sdk/client/index.js", () => ({
+  __esModule: true,
+  Client: MockClient,
+}));
+
+jest.unstable_mockModule("@modelcontextprotocol/sdk/client/stdio", () => ({
+  __esModule: true,
+  StdioClientTransport: function (opts: unknown) {
+    mockStdio(opts);
+  },
+}));
+
+jest.unstable_mockModule(
+  "@modelcontextprotocol/sdk/client/streamableHttp.js",
+  () => ({
+    __esModule: true,
+    StreamableHTTPClientTransport: function (url: unknown, opts: unknown) {
+      mockHttp(url, opts);
+    },
+  }),
+);
+
+jest.unstable_mockModule("../src/helpers.ts", () => ({
+  __esModule: true,
+  log: (...args: unknown[]) => mockLog(...args),
+}));
+
+let connectMcp: typeof import("../src/mcp.ts").connectMcp;
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockConnect.mockReset();
+  mockStdio.mockReset();
+  mockHttp.mockReset();
+  mockLog.mockReset();
+  ({ connectMcp } = await import("../src/mcp.ts"));
+});
+
+describe("connectMcp", () => {
+  it("returns cached client", async () => {
+    const existing = {} as unknown as Client;
+    const res = await connectMcp("m", {} as any, { m: existing });
+    expect(res).toEqual({ model: "m", client: existing, connected: true });
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
+
+  it("connects via serverUrl", async () => {
+    const clients: Record<string, Client> = {};
+    const res = await connectMcp(
+      "m",
+      { serverUrl: "http://s" } as any,
+      clients,
+    );
+    expect(mockHttp).toHaveBeenCalledWith(new URL("http://s"), {
+      sessionId: undefined,
+    });
+    expect(mockConnect).toHaveBeenCalled();
+    expect(res.connected).toBe(true);
+  });
+
+  it("connects via command", async () => {
+    const clients: Record<string, Client> = {};
+    const res = await connectMcp(
+      "m",
+      { command: "cmd", args: ["a"], env: { A: "1" } } as any,
+      clients,
+    );
+    expect(mockStdio).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "cmd",
+        args: ["a"],
+        env: expect.objectContaining({
+          A: "1",
+          NODE_OPTIONS: expect.stringContaining("--unhandled-rejections=warn"),
+        }),
+      }),
+    );
+    expect(mockConnect).toHaveBeenCalled();
+    expect(res.connected).toBe(true);
+  });
+
+  it("returns disconnected on error", async () => {
+    mockConnect.mockRejectedValue(new Error("bad"));
+    const res = await connectMcp("m", { serverUrl: "http://s" } as any, {});
+    expect(res).toEqual({ model: "m", client: null, connected: false });
+    expect(mockLog).toHaveBeenCalled();
+  });
+
+  it("handles missing transport", async () => {
+    const res = await connectMcp("m", {} as any, {});
+    expect(res.connected).toBe(false);
+  });
+});

--- a/tests/httpHandlersAgent.test.ts
+++ b/tests/httpHandlersAgent.test.ts
@@ -1,0 +1,159 @@
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import type { Request, Response } from "express";
+
+const mockUseConfig = jest.fn();
+const mockRequestGptAnswer = jest.fn();
+const mockAddToHistory = jest.fn();
+const mockLog = jest.fn();
+
+jest.unstable_mockModule("../src/config.ts", () => ({
+  __esModule: true,
+  useConfig: () => mockUseConfig(),
+  readConfig: () => ({}),
+}));
+
+jest.unstable_mockModule("../src/helpers/gpt/llm.ts", () => ({
+  __esModule: true,
+  requestGptAnswer: (...args: unknown[]) => mockRequestGptAnswer(...args),
+}));
+
+jest.unstable_mockModule("../src/helpers/history.ts", () => ({
+  __esModule: true,
+  addToHistory: (...args: unknown[]) => mockAddToHistory(...args),
+  forgetHistoryOnTimeout: () => undefined,
+}));
+
+jest.unstable_mockModule("../src/helpers.ts", () => ({
+  __esModule: true,
+  log: (...args: unknown[]) => mockLog(...args),
+  agentNameToId: (name: string) => name.length,
+  sendToHttp: jest.fn(),
+}));
+
+let agentPostHandler: typeof import("../src/httpHandlers.ts").agentPostHandler;
+let agentGetHandler: typeof import("../src/httpHandlers.ts").agentGetHandler;
+
+function createRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+    end: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    contentType: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockUseConfig.mockReset();
+  mockRequestGptAnswer.mockReset();
+  mockAddToHistory.mockReset();
+  mockLog.mockReset();
+  ({ agentPostHandler, agentGetHandler } = await import(
+    "../src/httpHandlers.ts"
+  ));
+});
+
+afterEach(() => {
+  (global.fetch as unknown as jest.Mock | undefined)?.mockRestore?.();
+});
+
+describe("agentGetHandler", () => {
+  it("responds with status info", async () => {
+    const res = createRes();
+    await agentGetHandler(
+      { params: { agentName: "a" } } as unknown as Request,
+      res,
+    );
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "a", status: "online" }),
+    );
+  });
+});
+
+describe("agentPostHandler", () => {
+  const baseConfig = {
+    http: { http_token: "t" },
+    chats: [
+      {
+        agent_name: "agent",
+        completionParams: {},
+        chatParams: {},
+        toolParams: {},
+      },
+    ],
+  };
+
+  it("rejects unauthorized requests", async () => {
+    mockUseConfig.mockReturnValue(baseConfig);
+    const req = {
+      params: { agentName: "agent" },
+      body: { text: "hi" },
+      headers: { authorization: "Bearer bad" },
+    } as unknown as Request;
+    const res = createRes();
+    await agentPostHandler(req, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("rejects missing text", async () => {
+    mockUseConfig.mockReturnValue(baseConfig);
+    const req = {
+      params: { agentName: "agent" },
+      body: {},
+      headers: { authorization: "Bearer t" },
+    } as unknown as Request;
+    const res = createRes();
+    await agentPostHandler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("rejects wrong agent", async () => {
+    mockUseConfig.mockReturnValue({ ...baseConfig, chats: [] });
+    const req = {
+      params: { agentName: "agent" },
+      body: { text: "hi" },
+      headers: { authorization: "Bearer t" },
+    } as unknown as Request;
+    const res = createRes();
+    await agentPostHandler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("sends answer when ok", async () => {
+    mockUseConfig.mockReturnValue(baseConfig);
+    mockRequestGptAnswer.mockResolvedValue({ content: "answer" });
+    const req = {
+      params: { agentName: "agent" },
+      body: { text: "hi" },
+      headers: { authorization: "Bearer t" },
+    } as unknown as Request;
+    const res = createRes();
+    await agentPostHandler(req, res);
+    expect(mockAddToHistory).toHaveBeenCalled();
+    expect(res.end).toHaveBeenCalledWith("answer");
+  });
+
+  it("posts webhook when provided", async () => {
+    mockUseConfig.mockReturnValue(baseConfig);
+    mockRequestGptAnswer.mockResolvedValue({ content: "a" });
+    const fetchMock = jest.fn().mockResolvedValue({});
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const req = {
+      params: { agentName: "agent" },
+      body: { text: "hi", webhook: "http://w" },
+      headers: { authorization: "Bearer t" },
+    } as unknown as Request;
+    const res = createRes();
+    await agentPostHandler(req, res);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for HTTP handlers
- test MCP connection logic

## Testing
- `npm run test-full`
- `npm run coverage-info`

------
https://chatgpt.com/codex/tasks/task_e_685ed26ba480832ca3a84f40817549ec