### PR TITLE
Fix coverage for real tool files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,6 +23,11 @@ const config = {
   ],
   setupFilesAfterEnv: ['<rootDir>/tests/setupTests.ts'],
   collectCoverage: true,
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/tools/foo.ts',
+    '!src/tools/bar.ts',
+  ],
   coverageDirectory: 'coverage',
   coverageReporters: [
     'json-summary',


### PR DESCRIPTION
## Summary
- include all src files in Jest coverage
- exclude dynamic foo.ts/bar.ts test files from coverage

## Testing
- `npm run test`
- `npm run coverage-info`


------
https://chatgpt.com/codex/tasks/task_e_685ee4b94088832caf5deccb9994a2d7