### PR TITLE
Improve coverage for commands and index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,9 @@ process.on("uncaughtException", (error, source) => {
   console.log("source:", source);
 });
 
-void start();
+if (process.env.NODE_ENV !== "test") {
+  void start();
+}
 
 async function start() {
   // global
@@ -297,3 +299,11 @@ async function telegramPostHandler(
     res.status(500).send("Error sending message.");
   }
 }
+
+export {
+  start,
+  launchBot,
+  initHttp,
+  telegramPostHandler,
+  telegramPostHandlerTest,
+};

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1,0 +1,214 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Message } from "telegraf/types";
+import type { ConfigChatType } from "../src/types";
+
+const mockUseTools = jest.fn();
+const mockSendTelegramMessage = jest.fn();
+const mockWriteConfig = jest.fn();
+const mockUseConfig = jest.fn();
+const mockGeneratePrivateChatConfig = jest.fn();
+const mockGetActionUserMsg = jest.fn();
+const mockGetSystemMessage = jest.fn();
+const mockGetTokensCount = jest.fn();
+const mockResolveChatTools = jest.fn();
+
+jest.unstable_mockModule("../src/helpers/useTools.ts", () => ({
+  __esModule: true,
+  default: () => mockUseTools(),
+}));
+
+jest.unstable_mockModule("../src/telegram/send.ts", () => ({
+  __esModule: true,
+  sendTelegramMessage: (...args: unknown[]) => mockSendTelegramMessage(...args),
+  getFullName: () => "",
+  getTelegramForwardedUser: () => "",
+  isAdminUser: () => true,
+  buildButtonRows: () => [],
+}));
+
+let actionCb: (ctx: any) => Promise<void>;
+const mockAction = jest.fn((name: string, cb: (ctx: any) => Promise<void>) => {
+  actionCb = cb;
+});
+
+jest.unstable_mockModule("../src/bot", () => ({
+  __esModule: true,
+  useBot: () => ({ action: mockAction }),
+}));
+
+let config: any;
+
+jest.unstable_mockModule("../src/config.ts", () => ({
+  __esModule: true,
+  useConfig: () => mockUseConfig(),
+  writeConfig: (...args: unknown[]) => mockWriteConfig(...args),
+  generatePrivateChatConfig: (u: string) => mockGeneratePrivateChatConfig(u),
+}));
+
+jest.unstable_mockModule("../src/telegram/context.ts", () => ({
+  __esModule: true,
+  getActionUserMsg: () => mockGetActionUserMsg(),
+  getCtxChatMsg: jest.fn(),
+}));
+
+jest.unstable_mockModule("../src/helpers/gpt.ts", () => ({
+  __esModule: true,
+  getSystemMessage: (...args: unknown[]) => mockGetSystemMessage(...args),
+  getTokensCount: (...args: unknown[]) => mockGetTokensCount(...args),
+  resolveChatTools: (...args: unknown[]) => mockResolveChatTools(...args),
+}));
+
+// for getInfoMessage internal call
+
+let commands: typeof import("../src/commands.ts");
+
+beforeEach(async () => {
+  jest.resetModules();
+  actionCb = async () => {};
+  config = {
+    adminUsers: ["admin"],
+    chats: [] as ConfigChatType[],
+  };
+  mockUseTools.mockReset();
+  mockUseTools.mockResolvedValue([]);
+  mockSendTelegramMessage.mockReset();
+  mockWriteConfig.mockReset();
+  mockUseConfig.mockReset().mockReturnValue(config);
+  mockGeneratePrivateChatConfig.mockReset().mockImplementation((u) => ({
+    name: `Private ${u}`,
+    username: u,
+    completionParams: {},
+    chatParams: {},
+    toolParams: {},
+  }));
+  mockGetActionUserMsg
+    .mockReset()
+    .mockReturnValue({ user: { username: "admin" } });
+  mockGetSystemMessage.mockReset().mockResolvedValue("sys");
+  mockGetTokensCount.mockReset().mockReturnValue(1);
+  mockResolveChatTools.mockReset().mockResolvedValue([]);
+
+  commands = await import("../src/commands.ts");
+});
+
+function createMsg(username = "user"): Message.TextMessage {
+  return {
+    chat: { id: 1, type: "private" },
+    from: { username },
+    text: "hi",
+  } as Message.TextMessage;
+}
+
+describe("getToolsInfo", () => {
+  it("returns available tools descriptions", async () => {
+    mockUseTools.mockResolvedValue([
+      { name: "foo", module: { description: "Foo" } },
+      { name: "bar", module: { description: "Bar" } },
+    ]);
+    config.chats.push({
+      agent_name: "agent1",
+      privateUsers: ["user1"],
+      completionParams: {},
+      chatParams: {},
+      toolParams: {},
+    });
+    const msg = createMsg("user1");
+    const res = await commands.getToolsInfo(
+      [
+        "foo",
+        { name: "agentTool", agent_name: "agent1", description: "D" },
+        "change_chat_settings",
+      ],
+      msg,
+    );
+    expect(res).toEqual(["- foo - Foo", "- agentTool - D"]);
+  });
+
+  it("skips agent tool when user not allowed", async () => {
+    mockUseTools.mockResolvedValue([
+      { name: "foo", module: { description: "Foo" } },
+    ]);
+    config.chats.push({
+      agent_name: "agent1",
+      privateUsers: ["user1"],
+      completionParams: {},
+      chatParams: {},
+      toolParams: {},
+    });
+    const msg = createMsg("other");
+    const res = await commands.getToolsInfo(
+      ["foo", { name: "agentTool", agent_name: "agent1", description: "D" }],
+      msg,
+    );
+    expect(res).toEqual(["- foo - Foo"]);
+  });
+});
+
+describe("commandAddTool", () => {
+  it("sends list and handles action", async () => {
+    mockUseTools.mockResolvedValue([
+      { name: "foo", module: { description: "Foo", defaultParams: { p: 1 } } },
+    ]);
+    const msg = createMsg();
+    const chat: ConfigChatType = {
+      bot_token: "t",
+      completionParams: {},
+      chatParams: {},
+      toolParams: {},
+      name: "c",
+    } as ConfigChatType;
+    mockSendTelegramMessage.mockResolvedValue("ok");
+    const res = await commands.commandAddTool(msg, chat);
+    expect(res).toBe("ok");
+    expect(mockSendTelegramMessage).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("Available tools"),
+      expect.objectContaining({
+        reply_markup: {
+          inline_keyboard: [[{ text: "foo", callback_data: "add_tool_foo" }]],
+        },
+      }),
+      undefined,
+      chat,
+    );
+    expect(mockAction).toHaveBeenCalledWith(
+      "add_tool_foo",
+      expect.any(Function),
+    );
+    const ctxReply = jest.fn();
+    await actionCb({ chat: { id: 2, type: "private" }, reply: ctxReply });
+    expect(config.chats[0].tools).toContain("foo");
+    expect(config.chats[0].toolParams).toEqual({ p: 1 });
+    expect(ctxReply).toHaveBeenCalledWith(
+      expect.stringContaining("Tool added: foo"),
+    );
+    expect(mockWriteConfig).toHaveBeenCalled();
+  });
+});
+
+describe("getInfoMessage", () => {
+  it("builds info string", async () => {
+    mockUseTools.mockResolvedValue([
+      { name: "foo", module: { description: "" } },
+    ]);
+    const chat: ConfigChatType = {
+      name: "c",
+      id: 1,
+      prefix: "!",
+      tools: ["foo"],
+      completionParams: { model: "m" },
+      chatParams: { forgetTimeout: 10, memoryless: true },
+      toolParams: {},
+    } as ConfigChatType;
+    const msg = createMsg();
+    const res = await commands.getInfoMessage(msg, chat);
+    expect(mockGetSystemMessage).toHaveBeenCalled();
+    expect(res).toContain("System: sys");
+    expect(res).toContain("Tokens: 1");
+    expect(res).toContain("Model: m");
+    expect(res).toContain("Forget timeout: 10");
+    expect(res).toContain("Chat is memoryless");
+    expect(res).toContain("Tools:\n- foo");
+    expect(res).toContain("Настройки приватного режима");
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,184 @@
+import { jest, describe, it, beforeEach, expect } from "@jest/globals";
+import type { Request, Response } from "express";
+
+const mockUseConfig = jest.fn();
+const mockValidateConfig = jest.fn();
+const mockWatchConfigChanges = jest.fn();
+const mockUseBot = jest.fn();
+const mockInitCommands = jest.fn();
+const mockWriteConfig = jest.fn();
+const mockLog = jest.fn();
+const mockUseMqtt = jest.fn();
+const mockOnTextMessage = jest.fn();
+const mockUseLastCtx = jest.fn();
+
+jest.unstable_mockModule("langfuse", () => ({
+  Langfuse: class {},
+  LangfuseTraceClient: class {},
+  observeOpenAI: jest.fn(),
+}));
+
+const expressApp = {
+  use: jest.fn(),
+  get: jest.fn(),
+  post: jest.fn(),
+  listen: jest.fn((_: number, cb: () => void) => cb()),
+};
+const mockExpress = jest.fn(() => expressApp);
+mockExpress.json = jest.fn(
+  () => (_req: Request, _res: Response, next: () => void) => next(),
+);
+
+jest.unstable_mockModule("../src/config.ts", () => ({
+  __esModule: true,
+  useConfig: () => mockUseConfig(),
+  validateConfig: (...args: unknown[]) => mockValidateConfig(...args),
+  writeConfig: (...args: unknown[]) => mockWriteConfig(...args),
+  watchConfigChanges: (...args: unknown[]) => mockWatchConfigChanges(...args),
+  readConfig: jest.fn(),
+}));
+
+jest.unstable_mockModule("../src/bot", () => ({
+  __esModule: true,
+  useBot: (...args: unknown[]) => mockUseBot(...args),
+  getBots: () => ({}),
+}));
+
+jest.unstable_mockModule("../src/commands.ts", () => ({
+  __esModule: true,
+  initCommands: (...args: unknown[]) => mockInitCommands(...args),
+}));
+
+jest.unstable_mockModule("../src/helpers.ts", () => ({
+  __esModule: true,
+  log: (...args: unknown[]) => mockLog(...args),
+  agentNameToId: jest.fn(),
+  sendToHttp: jest.fn(),
+}));
+
+jest.unstable_mockModule("../src/mqtt.ts", () => ({
+  __esModule: true,
+  useMqtt: () => mockUseMqtt(),
+  isMqttConnected: () => true,
+  publishMqttProgress: jest.fn(),
+}));
+
+jest.unstable_mockModule("../src/handlers/onTextMessage.ts", () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockOnTextMessage(...args),
+}));
+
+jest.unstable_mockModule("../src/helpers/lastCtx.ts", () => ({
+  __esModule: true,
+  useLastCtx: () => mockUseLastCtx(),
+}));
+
+jest.unstable_mockModule("express", () => ({
+  __esModule: true,
+  default: mockExpress,
+}));
+
+let index: typeof import("../src/index.ts");
+let telegramPostHandler: any;
+let telegramPostHandlerTest: any;
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockUseConfig.mockReset();
+  mockValidateConfig.mockReset().mockReturnValue(true);
+  mockWatchConfigChanges.mockReset();
+  mockUseBot.mockReset().mockReturnValue({
+    help: jest.fn(),
+    on: jest.fn(),
+    action: jest.fn(),
+    launch: jest.fn().mockResolvedValue(undefined),
+  });
+  mockInitCommands.mockReset();
+  mockWriteConfig.mockReset();
+  mockLog.mockReset();
+  mockUseMqtt.mockReset();
+  mockOnTextMessage
+    .mockReset()
+    .mockImplementation(async (_ctx, _o, cb) => cb({ text: "ok" }));
+  mockUseLastCtx.mockReset();
+  mockExpress.mockClear();
+
+  const config = {
+    auth: { bot_token: "t" },
+    bot_name: "main",
+    http: { telegram_from_username: "user", port: 3000 },
+    chats: [
+      {
+        id: 1,
+        name: "c",
+        bot_token: "b",
+        bot_name: "b",
+        completionParams: {},
+        chatParams: {},
+        toolParams: {},
+      },
+    ],
+  };
+  mockUseConfig.mockReturnValue(config);
+
+  index = await import("../src/index.ts");
+  telegramPostHandler = index.telegramPostHandler;
+  telegramPostHandlerTest = index.telegramPostHandlerTest;
+});
+
+function createRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+    end: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    contentType: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+describe("telegramPostHandler", () => {
+  it("rejects missing text", async () => {
+    const res = createRes();
+    await telegramPostHandler(
+      { params: { chatId: "1" }, body: {} } as unknown as Request,
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("returns error when chat not found", async () => {
+    const res = createRes();
+    mockUseConfig.mockReturnValueOnce({
+      auth: {},
+      bot_name: "m",
+      http: { telegram_from_username: "u" },
+      chats: [],
+    });
+    await telegramPostHandler(
+      { params: { chatId: "99" }, body: { text: "hi" } } as unknown as Request,
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("sends message when ok", async () => {
+    const res = createRes();
+    mockUseLastCtx.mockReturnValue({});
+    await telegramPostHandler(
+      { params: { chatId: "1" }, body: { text: "hi" } } as unknown as Request,
+      res,
+    );
+    expect(res.end).toHaveBeenCalledWith("ok");
+  });
+});
+
+describe("telegramPostHandlerTest", () => {
+  it("sets default params", async () => {
+    const req = { params: {}, body: {} } as unknown as Request;
+    const res = createRes();
+    mockUseLastCtx.mockReturnValue({});
+    await telegramPostHandlerTest(req, res);
+    expect(req.params.chatId).toBe("-4534736935");
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});


### PR DESCRIPTION
## Summary
- export useful functions from `index.ts` and avoid running bot during tests
- add tests for `commands.ts` covering tool info, add tool flow, and info message
- add tests for `index.ts` HTTP handlers

## Testing
- `npm run test-full`
- `npm run coverage-info`


------
https://chatgpt.com/codex/tasks/task_e_685ef7f319b0832c86a198f091f74e6b