### PR TITLE
Improve tool coverage

### DIFF
--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { jest, describe, it, expect, beforeEach } from "@jest/globals";
 import type { Message } from "telegraf/types";
 import type { ConfigChatType } from "../src/types";

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { jest, describe, it, beforeEach, expect } from "@jest/globals";
 import type { Request, Response } from "express";
 

--- a/tests/tools/change_chat_settings.test.ts
+++ b/tests/tools/change_chat_settings.test.ts
@@ -18,6 +18,7 @@ jest.unstable_mockModule("../../src/config.ts", () => ({
 }));
 
 let ChangeChatSettingsClient: typeof import("../../src/tools/change_chat_settings.ts").ChangeChatSettingsClient;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 let callFn: typeof import("../../src/tools/change_chat_settings.ts").call;
 
 beforeEach(async () => {

--- a/tests/tools/get_next_offday.test.ts
+++ b/tests/tools/get_next_offday.test.ts
@@ -1,0 +1,41 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { ToolResponse } from "../../src/types";
+
+const mockReadConfig = jest.fn();
+
+jest.unstable_mockModule("../../src/config.ts", () => ({
+  readConfig: () => mockReadConfig(),
+}));
+
+let mod: typeof import("../../src/tools/get_next_offday.ts");
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockReadConfig.mockReset();
+  mod = await import("../../src/tools/get_next_offday.ts");
+});
+
+describe("NextOffdayClient", () => {
+  it("calculates next off day", async () => {
+    const client = new mod.NextOffdayClient();
+    const res = await client.get_next_offday({
+      startOffDate: "2024-01-01",
+      currentDate: "2024-01-03",
+    });
+    expect(res).toEqual({ content: "2024-01-05" } as ToolResponse);
+  });
+
+  it("options_string formats args", () => {
+    const client = new mod.NextOffdayClient();
+    const str = client.options_string(
+      '{"startOffDate":"2024-01-01","currentDate":"2024-01-03"}',
+    );
+    expect(str).toBe("`get_next_offday(2024-01-01, 2024-01-03)`");
+  });
+
+  it("call returns instance", () => {
+    expect(mod.call()).toBeInstanceOf(mod.NextOffdayClient);
+  });
+});
+
+export {};

--- a/tests/tools/powershell.test.ts
+++ b/tests/tools/powershell.test.ts
@@ -1,0 +1,83 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { ToolResponse } from "../../src/types";
+
+const mockExec = jest.fn();
+
+jest.unstable_mockModule("child_process", () => ({
+  exec: (...args: unknown[]) => mockExec(...args),
+}));
+
+let mod: typeof import("../../src/tools/powershell.ts");
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockExec.mockReset();
+  mod = await import("../../src/tools/powershell.ts");
+});
+
+describe("PowershellCommandClient", () => {
+  it("executes command and returns output", async () => {
+    mockExec.mockImplementation(
+      (cmd: string, cb: (e: Error | null, out: string, err: string) => void) =>
+        cb(null, "ok", ""),
+    );
+    const client = new mod.PowershellCommandClient();
+    const res = await client.powershell({ command: "Get" });
+    expect(mockExec).toHaveBeenCalledWith(
+      'powershell -Command "Get"',
+      expect.any(Function),
+    );
+    expect(res).toEqual({ content: "```\nok\n```" } as ToolResponse);
+  });
+
+  it("returns exit code on error", async () => {
+    mockExec.mockImplementation(
+      (
+        cmd: string,
+        cb: (
+          e: (Error & { code?: number }) | null,
+          out: string,
+          err: string,
+        ) => void,
+      ) => {
+        const err: Error & { code?: number } = new Error("fail");
+        err.code = 1;
+        cb(err, "", "");
+      },
+    );
+    const client = new mod.PowershellCommandClient();
+    const res = await client.powershell({ command: "Fail" });
+    expect(res).toEqual({ content: "Exit code: 1" } as ToolResponse);
+  });
+
+  it("returns exit code 0 when no output", async () => {
+    mockExec.mockImplementation(
+      (cmd: string, cb: (e: Error | null, out: string, err: string) => void) =>
+        cb(null, "", ""),
+    );
+    const client = new mod.PowershellCommandClient();
+    const res = await client.powershell({ command: "None" });
+    expect(res).toEqual({ content: "Exit code: 0" } as ToolResponse);
+  });
+
+  it("rejects on stderr", async () => {
+    mockExec.mockImplementation(
+      (cmd: string, cb: (e: Error | null, out: string, err: string) => void) =>
+        cb(null, "", "err"),
+    );
+    const client = new mod.PowershellCommandClient();
+    await expect(client.powershell({ command: "Bad" })).rejects.toBe("err");
+  });
+
+  it("options_string formats command", () => {
+    const client = new mod.PowershellCommandClient();
+    const formatted = client.options_string('{"command":"ls"}');
+    expect(formatted).toBe("`Powershell:`\n```powershell\nls\n```");
+  });
+
+  it("call returns instance", () => {
+    expect(mod.call()).toBeInstanceOf(mod.PowershellCommandClient);
+  });
+});
+
+export {};

--- a/tests/tools/read_google_sheet.test.ts
+++ b/tests/tools/read_google_sheet.test.ts
@@ -1,0 +1,67 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { OAuth2Client } from "google-auth-library";
+import type {
+  ConfigChatType,
+  ThreadStateType,
+  ToolResponse,
+} from "../../src/types";
+
+const mockReadConfig = jest.fn();
+const mockReadSheet = jest.fn();
+
+jest.unstable_mockModule("../../src/config.ts", () => ({
+  readConfig: () => mockReadConfig(),
+}));
+
+jest.unstable_mockModule("../../src/helpers/readGoogleSheet.ts", () => ({
+  default: (...args: unknown[]) => mockReadSheet(...args),
+}));
+
+let mod: typeof import("../../src/tools/read_google_sheet.ts");
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockReadConfig.mockReset();
+  mockReadSheet.mockReset();
+  mod = await import("../../src/tools/read_google_sheet.ts");
+});
+
+describe("GoogleSheetClient", () => {
+  const auth = {} as OAuth2Client;
+
+  it("returns sheet data", async () => {
+    mockReadSheet.mockResolvedValue([{ a: 1 }]);
+    const client = new mod.GoogleSheetClient(auth);
+    const res = await client.read_google_sheet({ sheetId: "id" });
+    expect(mockReadSheet).toHaveBeenCalledWith("id", auth);
+    expect(res).toEqual({ content: '```json\n[{"a":1}]\n```' } as ToolResponse);
+  });
+
+  it("returns auth message when no data", async () => {
+    mockReadSheet.mockResolvedValue(undefined);
+    const client = new mod.GoogleSheetClient(auth);
+    const res = await client.read_google_sheet({ sheetId: "id" });
+    expect(res.content).toBe("No access token, auth with /google_auth");
+  });
+
+  it("options_string formats id", () => {
+    const client = new mod.GoogleSheetClient(auth);
+    expect(client.options_string('{"sheetId":"abc"}')).toBe(
+      "Read Google sheet: https://docs.google.com/spreadsheets/d/abc",
+    );
+    expect(client.options_string("{}" as string)).toBe("{}");
+  });
+
+  it("call returns instance", () => {
+    const cfg = {} as ConfigChatType;
+    const thread = {
+      id: 1,
+      msgs: [],
+      messages: [],
+      authClient: auth,
+    } as ThreadStateType;
+    expect(mod.call(cfg, thread)).toBeInstanceOf(mod.GoogleSheetClient);
+  });
+});
+
+export {};

--- a/tests/tools/ssh_command.test.ts
+++ b/tests/tools/ssh_command.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { jest, describe, it, expect, beforeEach } from "@jest/globals";
 import type { ConfigChatType } from "../../src/types";
 


### PR DESCRIPTION
## Summary
- add tests for `get_next_offday`, `powershell` and `read_google_sheet`
- silence lint warnings in existing tests

## Testing
- `npm run test-full`
- `npm run coverage-info`

------
https://chatgpt.com/codex/tasks/task_e_685f009725e4832ca6336a13bce172a9