### PR TITLE
Improve isMentioned prefixless replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,5 @@ This will execute all unit and integration tests in the `tests` directory using 
 ## TODO
 
 - [ ] Tool change_access_settings, for add/remove users to/from adminUsers, privateUsers
-- [ ] Union big incoming messages to single message
 - [ ] Show mqtt progress more verbose
 - [ ] В проекте есть скрытые замены "confirm", "noconfirm"

--- a/src/handlers/access.ts
+++ b/src/handlers/access.ts
@@ -53,35 +53,34 @@ export function isMentioned(
   msg: Message.TextMessage & { caption?: string },
   chat: ConfigChatType,
 ): boolean {
-  if (!chat.prefix) return true;
   const botName = chat.bot_name || useConfig().bot_name;
-  let mentioned = false;
+  const prefix = chat.prefix ?? "";
   const isPrivate = msg.chat.type === "private";
   const text =
     (msg as Message.TextMessage).text ||
     (msg as { caption?: string }).caption ||
     "";
 
-  if (
-    msg.reply_to_message &&
-    msg.from?.username !==
-      (msg.reply_to_message as Message.TextMessage).from?.username
-  ) {
-    if (
-      (msg.reply_to_message as Message.TextMessage).from?.username !== botName
-    )
-      return false;
-    mentioned = true;
-  }
+  const replyAuthor = (msg.reply_to_message as Message.TextMessage)?.from
+    ?.username;
+  const isReply = Boolean(
+    msg.reply_to_message && msg.from?.username !== replyAuthor,
+  );
+  const replyToBot = isReply && replyAuthor === botName;
+  const replyToOther = isReply && replyAuthor !== botName;
 
-  if (!mentioned && !isPrivate) {
-    const re = new RegExp(`^${chat.prefix}`, "i");
-    const isBot = re.test(text);
-    if (!isBot) {
-      const mention = new RegExp(`@${botName}`, "i");
-      mentioned = mention.test(text);
-      if (!mentioned) return false;
-    }
+  if (replyToOther) return false;
+  if (!prefix) return true;
+
+  if (replyToBot) return true;
+  if (!isPrivate) {
+    const hasPrefix = new RegExp(`^${prefix}`, "i").test(text);
+    if (hasPrefix) return true;
+
+    const hasMention = new RegExp(`@${botName}`, "i").test(text);
+    if (hasMention) return true;
+
+    return false;
   }
 
   return true;

--- a/tests/handlers/isMentioned.test.ts
+++ b/tests/handlers/isMentioned.test.ts
@@ -41,6 +41,20 @@ describe("isMentioned", () => {
     expect(isMentioned(msg, chat)).toBe(true);
   });
 
+  it("returns false when no prefix and reply to other user", () => {
+    const chat = { ...baseChat, prefix: undefined } as ConfigChatType;
+    const msg = createMsg({
+      reply_to_message: {
+        chat: { id: 1, type: "group" },
+        from: { username: "other" },
+        message_id: 2,
+        date: 0,
+        text: "hi",
+      } as Message.TextMessage,
+    });
+    expect(isMentioned(msg, chat)).toBe(false);
+  });
+
   it("detects prefix", () => {
     const msg = createMsg({ text: "!hello" });
     expect(isMentioned(msg, baseChat)).toBe(true);


### PR DESCRIPTION
## Summary
- tweak `isMentioned` logic
- add test for replying to another user when no prefix

## Testing
- `npm run test-full`
- `npm run coverage-info`


------
https://chatgpt.com/codex/tasks/task_e_6862bcda9c58832ca0259c2f9ad7a324