### PR TITLE
Handle admin forwarded messages

### DIFF
--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -235,7 +235,7 @@ export function getTelegramForwardedUser(
   const username = forwardOrigin?.sender_user?.username;
   const isOurUser =
     username &&
-    [chatConfig.privateUsers, useConfig().privateUsers]
+    [chatConfig.privateUsers, useConfig().privateUsers, useConfig().adminUsers]
       .flat()
       .includes(username);
   if (isOurUser) return "";

--- a/tests/telegram/send.test.ts
+++ b/tests/telegram/send.test.ts
@@ -109,4 +109,14 @@ describe("getTelegramForwardedUser", () => {
     } as unknown as Message.TextMessage;
     expect(getTelegramForwardedUser(msg, chat)).toBe("");
   });
+
+  it("returns empty when user is admin", () => {
+    const msg = {
+      forward_origin: {
+        type: "user",
+        sender_user: { first_name: "Admin", username: "admin" },
+      },
+    } as unknown as Message.TextMessage;
+    expect(getTelegramForwardedUser(msg, baseChat)).toBe("");
+  });
 });


### PR DESCRIPTION
## Summary
- ensure `adminUsers` are ignored when showing forwarded user details
- test that forwarded messages from admins return empty string

## Testing
- `npm run test-full`

------
https://chatgpt.com/codex/tasks/task_e_6862ff44d758832c9e7bae145f5a1f73