### PR TITLE
Refactor addToHistory thread init

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -36,10 +36,7 @@ export async function runAgent(
   });
 
   // Add user message to history before requesting answer
-  addToHistory({
-    msg,
-    completionParams: chat.completionParams,
-  });
+  addToHistory(msg, chat);
   forgetHistoryOnTimeout(chat, msg);
 
   const res = await requestGptAnswer(msg, chat as ConfigChatType, ctx);

--- a/src/helpers/gpt/llm.ts
+++ b/src/helpers/gpt/llm.ts
@@ -98,7 +98,7 @@ async function evaluateAnswer(
   msg: Message.TextMessage,
   evaluator: ConfigChatType,
   task: string,
-  answer: string
+  answer: string,
 ): Promise<EvaluatorResult> {
   const systemMessage = [EVALUATOR_PROMPT, evaluator.systemMessage]
     .filter(Boolean)
@@ -160,7 +160,7 @@ export async function handleModelAnswer({
 
   if (!messageAgent.tool_calls || messageAgent.tool_calls.length === 0) {
     const toolCallMatches = messageAgent.content?.matchAll(
-      /<tool_call>([\s\S]*?)<\/tool_call>/g
+      /<tool_call>([\s\S]*?)<\/tool_call>/g,
     );
     if (toolCallMatches) {
       const tool_calls =
@@ -186,7 +186,7 @@ export async function handleModelAnswer({
       chatConfig,
       msg,
       expressRes,
-      noSendTelegram
+      noSendTelegram,
     );
     if (tool_res) {
       return processToolResults({
@@ -203,7 +203,7 @@ export async function handleModelAnswer({
   }
 
   const answer = res.choices[0]?.message.content || "";
-  addToHistory({ msg, answer });
+  addToHistory(msg, chatConfig, answer);
 
   if (trace) {
     (trace as unknown as { update: (arg: unknown) => void }).update({
@@ -213,7 +213,7 @@ export async function handleModelAnswer({
 
   if (
     gptContext.thread.messages.find(
-      (m: OpenAI.ChatCompletionMessageParam) => m.role === "tool"
+      (m: OpenAI.ChatCompletionMessageParam) => m.role === "tool",
     ) &&
     chatConfig.chatParams?.memoryless
   ) {
@@ -246,7 +246,7 @@ export async function processToolResults({
       }
     ).tool_calls[i];
     const chatTool = gptContext.chatTools.find(
-      (f) => f.name === toolCall.function.name
+      (f) => f.name === toolCall.function.name,
     );
     const isMcp = chatTool?.module.call(chatConfig, gptContext.thread).mcp;
     const showMessages =
@@ -263,7 +263,7 @@ export async function processToolResults({
         msgContentLimited,
         params,
         undefined,
-        chatConfig
+        chatConfig,
       );
     }
 
@@ -300,7 +300,7 @@ export async function processToolResults({
 
   gptContext.messages = await buildMessages(
     gptContext.systemMessage,
-    gptContext.thread.messages
+    gptContext.thread.messages,
   );
 
   const isNoTool = level > 6 || !gptContext.tools?.length;
@@ -353,7 +353,7 @@ export async function requestGptAnswer(
     skipEvaluators?: boolean;
     responseFormat?: OpenAI.Chat.Completions.ChatCompletionCreateParams["response_format"];
     signal?: AbortSignal;
-  }
+  },
 ) {
   if (!msg.text) return;
   const threads = useThreads();
@@ -391,14 +391,14 @@ export async function requestGptAnswer(
   systemMessage = systemMessage.replace(/\{date}/g, date);
   systemMessage = await replaceUrlPlaceholders(
     systemMessage,
-    chatConfig.chatParams.placeholderCacheTime
+    chatConfig.chatParams.placeholderCacheTime,
   );
   systemMessage = await replaceToolPlaceholders(
     systemMessage,
     chatTools,
     chatConfig,
     thread,
-    chatConfig.chatParams.placeholderCacheTime
+    chatConfig.chatParams.placeholderCacheTime,
   );
   if (thread.nextSystemMessage) {
     systemMessage = thread.nextSystemMessage || "";
@@ -452,7 +452,7 @@ export async function requestGptAnswer(
     result.content = await runEvaluatorWorkflow(
       msg,
       chatConfig,
-      result.content
+      result.content,
     );
   }
 
@@ -462,7 +462,7 @@ export async function requestGptAnswer(
 async function runEvaluatorWorkflow(
   msg: Message.TextMessage,
   chatConfig: ConfigChatType,
-  answer: string
+  answer: string,
 ): Promise<string> {
   const config = useConfig();
   let finalAnswer = answer;
@@ -475,7 +475,7 @@ async function runEvaluatorWorkflow(
       msg,
       evalChat,
       msg.text || "",
-      finalAnswer
+      finalAnswer,
     );
     log({
       msg: `evaluation 1: ${JSON.stringify(evaluation)}`,
@@ -506,7 +506,7 @@ async function runEvaluatorWorkflow(
         msg,
         evalChat,
         msg.text || "",
-        finalAnswer
+        finalAnswer,
       );
       log({
         msg: `evaluation ${iter}: ${JSON.stringify(evaluation)}`,

--- a/src/httpHandlers.ts
+++ b/src/httpHandlers.ts
@@ -103,10 +103,7 @@ export async function agentPostHandler(
   });
 
   // Add user message to history before requesting answer
-  addToHistory({
-    msg,
-    completionParams: agentConfig.completionParams,
-  });
+  addToHistory(msg, agentConfig);
 
   const resObj = await requestGptAnswer(msg, agentConfig, {
     noSendTelegram: true,

--- a/tests/agent-runner.test.ts
+++ b/tests/agent-runner.test.ts
@@ -55,10 +55,7 @@ describe("runAgent", () => {
     expect(res).toBe("answer");
     const msg = mockRequestGptAnswer.mock.calls[0][0];
     expect(msg.text).toBe("hi");
-    expect(mockAddToHistory).toHaveBeenCalledWith({
-      msg,
-      completionParams: chat.completionParams,
-    });
+    expect(mockAddToHistory).toHaveBeenCalledWith(msg, chat);
     expect(mockForgetHistoryOnTimeout).toHaveBeenCalledWith(chat, msg);
     const ctx = mockRequestGptAnswer.mock.calls[0][2];
     expect(ctx.noSendTelegram).toBe(true);

--- a/tests/handlers/onTextMessageCancel.test.ts
+++ b/tests/handlers/onTextMessageCancel.test.ts
@@ -100,6 +100,7 @@ jest.unstable_mockModule("../../src/helpers/history.ts", () => ({
   addToHistory: mockAddToHistory,
   forgetHistoryOnTimeout: jest.fn(),
   forgetHistory: jest.fn(),
+  initThread: jest.fn(() => ({ id: 1, msgs: [], messages: [], completionParams: {} })),
 }));
 
 jest.unstable_mockModule("../../src/handlers/resolveChatButtons.ts", () => ({

--- a/tests/handlers/onTextMessageOuter.test.ts
+++ b/tests/handlers/onTextMessageOuter.test.ts
@@ -26,6 +26,7 @@ jest.unstable_mockModule("../../src/helpers/history.ts", () => ({
   addToHistory: (...args: unknown[]) => mockAddToHistory(...args),
   forgetHistoryOnTimeout: jest.fn(),
   forgetHistory: jest.fn(),
+  initThread: jest.fn(() => ({ id: 1, msgs: [], messages: [], completionParams: {} })),
 }));
 
 jest.unstable_mockModule("../../src/handlers/resolveChatButtons.ts", () => ({
@@ -40,7 +41,7 @@ jest.unstable_mockModule("../../src/threads.ts", () => ({
 let onTextMessage: (ctx: Context & { secondTry?: boolean }) => Promise<void>;
 
 function createCtx(
-  message: Record<string, unknown>
+  message: Record<string, unknown>,
 ): Context & { secondTry?: boolean } {
   return {
     message,

--- a/tests/helpers/history.test.ts
+++ b/tests/helpers/history.test.ts
@@ -41,7 +41,7 @@ describe("history helpers", () => {
 
   it("adds message with username", () => {
     const msg = createMsg("hi");
-    addToHistory({ msg, showTelegramNames: true });
+    addToHistory(msg, { ...baseChat, chatParams: { showTelegramNames: true } });
     expect(threads[1].messages[0]).toEqual({
       role: "user",
       content: "John Doe:\nhi",


### PR DESCRIPTION
## Summary
- add `initThread` and `buildUserMessage`
- update `addToHistory` signature
- call thread initialization from `onTextMessage`
- adjust call sites and tests

## Testing
- `npm run test-full`
- `npm run coverage-info`

------
https://chatgpt.com/codex/tasks/task_e_68657e951304832c92e9a929961809d7