### PR TITLE
Remove deprecated showTelegramNames

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
 - [ ] Show mqtt progress more verbose
-- [ ] showTelegramNames is deprecated, remove it from the project
+- [x] showTelegramNames is deprecated, remove it from the project
 - [ ] When chat has bot_name, and I've added the bot to the new group, bot doesn't check access level
 - [ ] Сделать миграцию на новый `npm install openai`. Инструкция по миграции - https://github.com/openai/openai-node/blob/master/MIGRATION.md
 - [ ] Tool change_access_settings, for add/remove users to/from adminUsers, privateUsers - 
 - [ ] В проекте есть скрытые замены "confirm", "noconfirm"
 - [ ] В addToHistory инициализируется threads, это неочевидно. Нужно вынести инициализацию threads в отдельную функцию
-- [ ] Убрать showTelegramNames
+- [x] Убрать showTelegramNames

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,7 +133,6 @@ export function generateConfig(): ConfigType {
           deleteToolAnswers: 60,
           confirmation: false,
           showToolMessages: true,
-          showTelegramNames: false,
         },
         toolParams: {
           brainstorm: {
@@ -176,7 +175,6 @@ export function generateConfig(): ConfigType {
           deleteToolAnswers: 60,
           confirmation: false,
           showToolMessages: true,
-          showTelegramNames: false,
         },
         toolParams: {
           brainstorm: {
@@ -247,9 +245,18 @@ export function checkConfigSchema(config: ConfigType) {
     (c) => c.name === "full-example",
   ) as ConfigChatType;
   const chatKeys = Object.keys(exampleChat) as Array<keyof ConfigChatType>;
-  config.chats.forEach((c, idx) =>
-    checkKeys(c as Record<string, unknown>, chatKeys, `chats[${idx}].`),
-  );
+  config.chats.forEach((c, idx) => {
+    checkKeys(c as Record<string, unknown>, chatKeys, `chats[${idx}].`);
+    if (
+      c.chatParams &&
+      Object.prototype.hasOwnProperty.call(c.chatParams, "showTelegramNames")
+    ) {
+      log({
+        msg: `chats[${idx}].chatParams.showTelegramNames is deprecated and ignored`,
+        logLevel: "warn",
+      });
+    }
+  });
 }
 
 export function logConfigChanges(oldConfig: ConfigType, newConfig: ConfigType) {

--- a/src/handlers/onTextMessage.ts
+++ b/src/handlers/onTextMessage.ts
@@ -27,7 +27,7 @@ const activeResponses = new Map<number, ActiveResponse>();
 export default async function onTextMessage(
   ctx: Context & { secondTry?: boolean },
   next?: () => Promise<void> | void,
-  callback?: (msg: Message.TextMessage) => Promise<void> | void
+  callback?: (msg: Message.TextMessage) => Promise<void> | void,
 ) {
   const threads = useThreads();
   setLastCtx(ctx);
@@ -69,7 +69,7 @@ export default async function onTextMessage(
     msg,
     chat,
     thread,
-    extraMessageParams
+    extraMessageParams,
   );
   if (buttonResponse) return buttonResponse;
 
@@ -77,7 +77,6 @@ export default async function onTextMessage(
   addToHistory({
     msg,
     completionParams: chat.completionParams,
-    showTelegramNames: chat.chatParams?.showTelegramNames,
   });
   forgetHistoryOnTimeout(chat, msg);
 
@@ -138,7 +137,7 @@ export async function answerToMessage(
   ctx: Context & { secondTry?: boolean },
   msg: Message.TextMessage,
   chat: ConfigChatType,
-  extraMessageParams: Record<string, unknown> & { signal?: AbortSignal }
+  extraMessageParams: Record<string, unknown> & { signal?: AbortSignal },
 ): Promise<Message.TextMessage | undefined> {
   log({
     msg: "answerToMessage",
@@ -165,13 +164,13 @@ export async function answerToMessage(
             "Ошибка синхронизации",
             undefined,
             ctx,
-            chat
+            chat,
           );
           return;
         }
 
         const extraParams = Markup.keyboard(
-          buttons.map((b) => b.name)
+          buttons.map((b) => b.name),
         ).resize();
         const answer = `Готово: ${buttons.map((b) => b.name).join(", ")}`;
         syncResult = await sendTelegramMessage(
@@ -179,7 +178,7 @@ export async function answerToMessage(
           answer,
           extraParams,
           ctx,
-          chat
+          chat,
         );
       });
       return syncResult;
@@ -208,7 +207,7 @@ export async function answerToMessage(
       const buttons = chat.buttonsSynced || chat.buttons;
       if (buttons) {
         const extraParamsButtons = Markup.keyboard(
-          buttons.map((b) => b.name)
+          buttons.map((b) => b.name),
         ).resize();
         Object.assign(extraParams, extraParamsButtons);
       }
@@ -225,7 +224,7 @@ export async function answerToMessage(
         text,
         extraParams,
         ctx,
-        chat
+        chat,
       );
       if (msgSent?.chat.id) useThreads()[msgSent.chat.id].msgs.push(msgSent);
     });
@@ -245,7 +244,7 @@ export async function answerToMessage(
       `${error.message}${ctx.secondTry ? "\n\nПовторная отправка последнего сообщения..." : ""}`,
       extraMessageParams,
       ctx,
-      chat
+      chat,
     );
   }
 }

--- a/src/helpers/history.ts
+++ b/src/helpers/history.ts
@@ -1,6 +1,6 @@
 import { Message } from "telegraf/types";
 import { CompletionParamsType, ConfigChatType } from "../types.ts";
-import { getFullName, isOurUser } from "../telegram/send.ts";
+import { isOurUser } from "../telegram/send.ts";
 import OpenAI from "openai";
 import { useThreads } from "../threads.ts";
 import { useConfig } from "../config.ts";
@@ -9,12 +9,10 @@ export function addToHistory({
   msg,
   answer,
   completionParams,
-  showTelegramNames,
 }: {
   msg: Message.TextMessage;
   answer?: string;
   completionParams?: CompletionParamsType;
-  showTelegramNames?: boolean;
 }) {
   const key = msg.chat?.id || 0;
   const threads = useThreads();
@@ -33,15 +31,11 @@ export function addToHistory({
       content: answer,
     };
   } else {
-    let content = msg.text || "";
-    if (showTelegramNames) {
-      const name = getFullName(msg);
-      if (name) {
-        content = `${name}:\n${content}`;
-      }
-    }
+    const content = msg.text || "";
     const sender = msg.forward_from || msg.from;
-    const chatConfig = useConfig().chats.find((c) => c.id === msg.chat.id) as ConfigChatType;
+    const chatConfig = useConfig().chats.find(
+      (c) => c.id === msg.chat.id,
+    ) as ConfigChatType;
     const isOur = isOurUser(sender, chatConfig);
     let name = sender?.first_name || sender?.last_name || sender?.username;
     if (isOur && chatConfig?.chatParams?.markOurUsers) {
@@ -87,7 +81,6 @@ export function forgetHistoryOnTimeout(
       addToHistory({
         msg,
         completionParams: chat.completionParams,
-        showTelegramNames: chat.chatParams?.showTelegramNames,
       });
       return true;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,6 @@ export type ChatParamsType = {
   memoryless?: boolean;
   forgetTimeout?: number; // in seconds
   showToolMessages?: true | false | undefined | "headers";
-  showTelegramNames?: boolean; // deprecated
   markOurUsers?: string;
   placeholderCacheTime?: number;
 };

--- a/testConfig.yml
+++ b/testConfig.yml
@@ -30,7 +30,6 @@ chats:
       deleteToolAnswers: 60
       confirmation: false
       showToolMessages: true
-      showTelegramNames: false
     toolParams:
       brainstorm:
         promptBefore: Составь только краткий план действий.

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -191,4 +191,17 @@ describe("checkConfigSchema", () => {
     readConfig("testConfig.yml");
     expect(console.warn).toHaveBeenCalled();
   });
+
+  it("warns about deprecated showTelegramNames", () => {
+    mockExistsSync.mockReturnValue(true);
+    const cfg = generateConfig();
+    Object.assign(cfg.chats[0].chatParams as Record<string, unknown>, {
+      showTelegramNames: true,
+    });
+    mockReadFileSync.mockReturnValue("yaml");
+    mockLoad.mockReturnValue(cfg);
+
+    readConfig("testConfig.yml");
+    expect(console.warn).toHaveBeenCalled();
+  });
 });

--- a/tests/helpers/history.test.ts
+++ b/tests/helpers/history.test.ts
@@ -9,7 +9,6 @@ jest.unstable_mockModule("../../src/threads.ts", () => ({
 }));
 
 jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
-  getFullName: () => "John Doe",
   isOurUser: jest.fn(),
 }));
 
@@ -39,12 +38,12 @@ describe("history helpers", () => {
     toolParams: {},
   } as ConfigChatType;
 
-  it("adds message with username", () => {
+  it("adds message", () => {
     const msg = createMsg("hi");
-    addToHistory({ msg, showTelegramNames: true });
+    addToHistory({ msg });
     expect(threads[1].messages[0]).toEqual({
       role: "user",
-      content: "John Doe:\nhi",
+      content: "hi",
       name: "John",
     });
     expect(threads[1].msgs[0]).toBe(msg);


### PR DESCRIPTION
## Summary
- drop `showTelegramNames` option across codebase
- warn in `checkConfigSchema` if `showTelegramNames` is present
- update tests for removed option
- mark TODO items as done

## Testing
- `npm run format`
- `npm run test-full`

------
https://chatgpt.com/codex/tasks/task_e_68657f504740832cb438d0470f472946