### PR TITLE
Remove deprecated showTelegramNames

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
 - [ ] Show mqtt progress more verbose
-- [ ] showTelegramNames is deprecated, remove it from the project
+- [x] showTelegramNames is deprecated, remove it from the project
 - [ ] When chat has bot_name, and I've added the bot to the new group, bot doesn't check access level
 - [ ] Сделать миграцию на новый `npm install openai`. Инструкция по миграции - https://github.com/openai/openai-node/blob/master/MIGRATION.md
 - [ ] Tool change_access_settings, for add/remove users to/from adminUsers, privateUsers - 
 - [ ] В проекте есть скрытые замены "confirm", "noconfirm"
 - [ ] В addToHistory инициализируется threads, это неочевидно. Нужно вынести инициализацию threads в отдельную функцию
-- [ ] Убрать showTelegramNames
+- [x] Убрать showTelegramNames

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,7 +133,6 @@ export function generateConfig(): ConfigType {
           deleteToolAnswers: 60,
           confirmation: false,
           showToolMessages: true,
-          showTelegramNames: false,
         },
         toolParams: {
           brainstorm: {
@@ -176,7 +175,6 @@ export function generateConfig(): ConfigType {
           deleteToolAnswers: 60,
           confirmation: false,
           showToolMessages: true,
-          showTelegramNames: false,
         },
         toolParams: {
           brainstorm: {
@@ -247,9 +245,18 @@ export function checkConfigSchema(config: ConfigType) {
     (c) => c.name === "full-example",
   ) as ConfigChatType;
   const chatKeys = Object.keys(exampleChat) as Array<keyof ConfigChatType>;
-  config.chats.forEach((c, idx) =>
-    checkKeys(c as Record<string, unknown>, chatKeys, `chats[${idx}].`),
-  );
+  config.chats.forEach((c, idx) => {
+    checkKeys(c as Record<string, unknown>, chatKeys, `chats[${idx}].`);
+    if (
+      c.chatParams &&
+      "showTelegramNames" in (c.chatParams as Record<string, unknown>)
+    ) {
+      log({
+        msg: `chats[${c.name || idx}].chatParams.showTelegramNames is deprecated`,
+        logLevel: "warn",
+      });
+    }
+  });
 }
 
 export function logConfigChanges(oldConfig: ConfigType, newConfig: ConfigType) {

--- a/src/helpers/history.ts
+++ b/src/helpers/history.ts
@@ -1,6 +1,6 @@
 import { Message } from "telegraf/types";
 import { ConfigChatType } from "../types.ts";
-import { getFullName, isOurUser } from "../telegram/send.ts";
+import { isOurUser } from "../telegram/send.ts";
 import OpenAI from "openai";
 import { useThreads } from "../threads.ts";
 
@@ -26,12 +26,6 @@ export function buildUserMessage(
   chatConfig: ConfigChatType,
 ): OpenAI.ChatCompletionMessageParam {
   let content = msg.text || "";
-  if (chatConfig.chatParams?.showTelegramNames) {
-    const name = getFullName(msg);
-    if (name) {
-      content = `${name}:\n${content}`;
-    }
-  }
   const sender = msg.forward_from || msg.from;
   const isOur = isOurUser(sender, chatConfig);
   let name = sender?.first_name || sender?.last_name || sender?.username;

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,6 @@ export type ChatParamsType = {
   memoryless?: boolean;
   forgetTimeout?: number; // in seconds
   showToolMessages?: true | false | undefined | "headers";
-  showTelegramNames?: boolean; // deprecated
   markOurUsers?: string;
   placeholderCacheTime?: number;
 };

--- a/testConfig.yml
+++ b/testConfig.yml
@@ -30,7 +30,6 @@ chats:
       deleteToolAnswers: 60
       confirmation: false
       showToolMessages: true
-      showTelegramNames: false
     toolParams:
       brainstorm:
         promptBefore: Составь только краткий план действий.

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -191,4 +191,15 @@ describe("checkConfigSchema", () => {
     readConfig("testConfig.yml");
     expect(console.warn).toHaveBeenCalled();
   });
+
+  it("warns about deprecated showTelegramNames", () => {
+    mockExistsSync.mockReturnValue(true);
+    const cfg = generateConfig();
+    cfg.chats[0].chatParams = { showTelegramNames: true } as any;
+    mockReadFileSync.mockReturnValue("yaml");
+    mockLoad.mockReturnValue(cfg);
+
+    readConfig("testConfig.yml");
+    expect(console.warn).toHaveBeenCalled();
+  });
 });

--- a/tests/helpers/history.test.ts
+++ b/tests/helpers/history.test.ts
@@ -39,12 +39,12 @@ describe("history helpers", () => {
     toolParams: {},
   } as ConfigChatType;
 
-  it("adds message with username", () => {
+  it("adds message", () => {
     const msg = createMsg("hi");
-    addToHistory(msg, { ...baseChat, chatParams: { showTelegramNames: true } });
+    addToHistory(msg, baseChat);
     expect(threads[1].messages[0]).toEqual({
       role: "user",
-      content: "John Doe:\nhi",
+      content: "hi",
       name: "John",
     });
     expect(threads[1].msgs[0]).toBe(msg);


### PR DESCRIPTION
## Summary
- remove `showTelegramNames` option from history helpers and default config
- warn in `checkConfigSchema` when the deprecated field is used
- update unit tests
- mark TODO items as completed

## Testing
- `npm run format`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_6865945848ec832cbe3342897a5abe7f