### PR TITLE
Improve index.ts testability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,14 +135,14 @@ async function launchBot(bot_token: string, bot_name: string) {
   }
 }
 
-function initHttp() {
+function createHttpApp() {
   // Validate HTTP configuration
   if (!useConfig().http) {
     log({
       msg: `Invalid http configuration in config, skip http server init`,
       logLevel: "warn",
     });
-    return;
+    return null;
   }
 
   const port = useConfig().http.port || 7586;
@@ -158,7 +158,7 @@ function initHttp() {
   });
 
   // Add /ping test route
-  app.get("/ping", (req, res) => {
+  app.get("/ping", (_req, res) => {
     res.send("pong");
   });
 
@@ -200,9 +200,17 @@ function initHttp() {
   // @ts-expect-error express types
   app.post("/agent/:agentName/tool/:toolName", toolPostHandler);
 
+  return { app, port };
+}
+
+function initHttp() {
+  const result = createHttpApp();
+  if (!result) return null;
+  const { app, port } = result;
   app.listen(port, () => {
     log({ msg: `http server listening on port ${port}` });
   });
+  return app;
 }
 
 async function telegramPostHandlerTest(
@@ -315,6 +323,7 @@ async function telegramPostHandler(
 export {
   start,
   launchBot,
+  createHttpApp,
   initHttp,
   telegramPostHandler,
   telegramPostHandlerTest,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -195,7 +195,10 @@ describe("checkConfigSchema", () => {
   it("warns about deprecated showTelegramNames", () => {
     mockExistsSync.mockReturnValue(true);
     const cfg = generateConfig();
-    cfg.chats[0].chatParams = { showTelegramNames: true } as unknown as Record<string, unknown>;
+    cfg.chats[0].chatParams = { showTelegramNames: true } as unknown as Record<
+      string,
+      unknown
+    >;
     mockReadFileSync.mockReturnValue("yaml");
     mockLoad.mockReturnValue(cfg);
 

--- a/tests/index.http.test.ts
+++ b/tests/index.http.test.ts
@@ -1,0 +1,69 @@
+import { jest, describe, it, beforeEach, expect } from "@jest/globals";
+import type { Request, Response } from "express";
+
+const mockUseConfig = jest.fn();
+const mockLog = jest.fn();
+
+const expressApp = {
+  use: jest.fn(),
+  get: jest.fn(),
+  post: jest.fn(),
+  listen: jest.fn(),
+};
+const mockExpress = jest.fn(() => expressApp);
+mockExpress.json = jest.fn(
+  () => (_req: Request, _res: Response, next: () => void) => next(),
+);
+
+jest.unstable_mockModule("../src/config.ts", () => ({
+  __esModule: true,
+  useConfig: () => mockUseConfig(),
+  validateConfig: jest.fn(),
+  writeConfig: jest.fn(),
+  watchConfigChanges: jest.fn(),
+  readConfig: jest.fn(),
+  generatePrivateChatConfig: jest.fn(),
+  syncButtons: jest.fn(),
+}));
+
+jest.unstable_mockModule("../src/helpers.ts", () => ({
+  __esModule: true,
+  log: (...args: unknown[]) => mockLog(...args),
+  agentNameToId: jest.fn(),
+  sendToHttp: jest.fn(),
+}));
+
+jest.unstable_mockModule("express", () => ({
+  __esModule: true,
+  default: mockExpress,
+}));
+
+let index: typeof import("../src/index.ts");
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockUseConfig.mockReset();
+  mockLog.mockReset();
+  expressApp.use.mockClear();
+  expressApp.get.mockClear();
+  expressApp.post.mockClear();
+  expressApp.listen.mockClear();
+
+  index = await import("../src/index.ts");
+});
+
+describe("createHttpApp", () => {
+  it("returns express app", () => {
+    mockUseConfig.mockReturnValue({ http: { port: 3000 } });
+    const result = index.createHttpApp();
+    expect(result?.app).toBe(expressApp);
+    expect(result?.port).toBe(3000);
+    expect(expressApp.listen).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no http config", () => {
+    mockUseConfig.mockReturnValue({});
+    const result = index.createHttpApp();
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- extract HTTP server creation into new `createHttpApp`
- expose `createHttpApp` and add unit tests

## Testing
- `npm run test-full`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_68659cbfcf84832c89657bbb5dba487c