### PR TITLE
Refactor health and add_chat handlers

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -46,6 +46,19 @@ export async function handleAddTool(ctx: Context) {
   await commandAddTool(msg, chat);
 }
 
+export async function handleAddChat(ctx: Context) {
+  const chatId = ctx.chat?.id;
+  // @ts-expect-error title may not exist on chat type
+  const chatName = (ctx.chat as { title?: string })?.title || `Chat ${chatId}`;
+  if (!chatId) return;
+
+  const config = useConfig();
+  const newChat = { name: chatName, id: chatId } as ConfigChatType;
+  config.chats.push(newChat);
+  writeConfig(undefined, config);
+  await ctx.reply(`Chat added: ${chatName}`);
+}
+
 export async function initCommands(bot: Telegraf) {
   bot.command("forget", handleForget);
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -48,7 +48,6 @@ export async function handleAddTool(ctx: Context) {
 
 export async function handleAddChat(ctx: Context) {
   const chatId = ctx.chat?.id;
-  // @ts-expect-error title may not exist on chat type
   const chatName = (ctx.chat as { title?: string })?.title || `Chat ${chatId}`;
   if (!chatId) return;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { useConfig, validateConfig, watchConfigChanges } from "./config.ts";
 import { initCommands, handleAddChat } from "./commands.ts";
 import { log } from "./helpers.ts";
 import express from "express";
-import { useBot, getBots } from "./bot";
+import { useBot } from "./bot";
 import onTextMessage from "./handlers/onTextMessage.ts";
 import onPhoto from "./handlers/onPhoto.ts";
 import onAudio from "./handlers/onAudio.ts";
@@ -16,7 +16,7 @@ import {
   agentPostHandler,
   toolPostHandler,
 } from "./httpHandlers.ts";
-import { useMqtt, isMqttConnected } from "./mqtt.ts";
+import { useMqtt } from "./mqtt.ts";
 import { healthHandler } from "./healthcheck.ts";
 
 process.on("uncaughtException", (error, source) => {
@@ -63,7 +63,6 @@ async function start() {
 
 async function launchBot(bot_token: string, bot_name: string) {
   try {
-    const config = useConfig();
     const bot = useBot(bot_token);
 
     // Set up help command

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -291,3 +291,16 @@ describe("handleAddTool", () => {
     expect(mockSendTelegramMessage).toHaveBeenCalled();
   });
 });
+
+describe("handleAddChat", () => {
+  it("adds chat to config and replies", async () => {
+    const ctx = {
+      chat: { id: 5, title: "t" },
+      reply: jest.fn(),
+    } as unknown as Context;
+    await commands.handleAddChat(ctx);
+    expect(config.chats[0]).toEqual({ name: "t", id: 5 });
+    expect(mockWriteConfig).toHaveBeenCalledWith(undefined, config);
+    expect(ctx.reply).toHaveBeenCalledWith("Chat added: t");
+  });
+});

--- a/tests/healthHandler.test.ts
+++ b/tests/healthHandler.test.ts
@@ -1,0 +1,78 @@
+import { jest, describe, it, beforeEach, expect } from "@jest/globals";
+import type { Request, Response } from "express";
+
+const mockUseConfig = jest.fn();
+const mockGetBots = jest.fn();
+const mockIsMqttConnected = jest.fn();
+
+jest.unstable_mockModule("../src/config.ts", () => ({
+  __esModule: true,
+  useConfig: () => mockUseConfig(),
+}));
+
+jest.unstable_mockModule("../src/bot", () => ({
+  __esModule: true,
+  getBots: () => mockGetBots(),
+}));
+
+jest.unstable_mockModule("../src/mqtt.ts", () => ({
+  __esModule: true,
+  isMqttConnected: () => mockIsMqttConnected(),
+}));
+
+let healthHandler: typeof import("../src/healthcheck.ts").healthHandler;
+let getHealthStatus: typeof import("../src/healthcheck.ts").getHealthStatus;
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockUseConfig.mockReset();
+  mockGetBots.mockReset();
+  mockIsMqttConnected.mockReset();
+  ({ healthHandler, getHealthStatus } = await import("../src/healthcheck.ts"));
+});
+
+function createRes() {
+  return {
+    json: jest.fn(),
+  } as unknown as Response;
+}
+
+describe("getHealthStatus", () => {
+  it("returns healthy state", () => {
+    mockUseConfig.mockReturnValue({ mqtt: { host: "h" } });
+    mockIsMqttConnected.mockReturnValue(true);
+    mockGetBots.mockReturnValue({
+      b: {
+        polling: { abortController: { signal: { aborted: false } } },
+        botInfo: { username: "b" },
+      },
+    });
+    expect(getHealthStatus()).toEqual({ healthy: true, errors: [] });
+  });
+
+  it("returns errors when issues", () => {
+    mockUseConfig.mockReturnValue({ mqtt: { host: "h" } });
+    mockIsMqttConnected.mockReturnValue(false);
+    mockGetBots.mockReturnValue({
+      b: {
+        polling: { abortController: { signal: { aborted: true } } },
+        botInfo: { username: "b" },
+      },
+    });
+    expect(getHealthStatus()).toEqual({
+      healthy: false,
+      errors: ["MQTT is not connected", "Bot b is not running"],
+    });
+  });
+});
+
+describe("healthHandler", () => {
+  it("sends status json", () => {
+    const res = createRes();
+    mockUseConfig.mockReturnValue({ mqtt: { host: "" } });
+    mockIsMqttConnected.mockReturnValue(true);
+    mockGetBots.mockReturnValue({});
+    healthHandler({} as Request, res);
+    expect(res.json).toHaveBeenCalledWith({ healthy: true, errors: [] });
+  });
+});

--- a/tests/index.start.test.ts
+++ b/tests/index.start.test.ts
@@ -54,6 +54,7 @@ jest.unstable_mockModule("../src/bot.ts", () => ({
 jest.unstable_mockModule("../src/commands.ts", () => ({
   __esModule: true,
   initCommands: (...args: unknown[]) => mockInitCommands(...args),
+  handleAddChat: jest.fn(),
 }));
 
 jest.unstable_mockModule("../src/helpers.ts", () => ({

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -50,6 +50,7 @@ jest.unstable_mockModule("../src/bot", () => ({
 jest.unstable_mockModule("../src/commands.ts", () => ({
   __esModule: true,
   initCommands: (...args: unknown[]) => mockInitCommands(...args),
+  handleAddChat: jest.fn(),
 }));
 
 jest.unstable_mockModule("../src/helpers.ts", () => ({


### PR DESCRIPTION
## Summary
- move /health logic into `healthcheck.ts`
- provide `getHealthStatus` and `healthHandler`
- move `add_chat` handler to `commands.ts`
- adjust tests for new exports and cover new handlers

## Testing
- `npm run format`
- `npm run test-full`

------
https://chatgpt.com/codex/tasks/task_e_6865a09cad8c832cbe783baa8f03f728