### PR TITLE
Implement MCP loading time log

### DIFF
--- a/tests/mcp.connect.test.ts
+++ b/tests/mcp.connect.test.ts
@@ -136,4 +136,12 @@ describe("init", () => {
       { name: "t1", description: "d", properties: {}, model: "m1" },
     ]);
   });
+
+  it("logs loading time", async () => {
+    listToolsMock.mockResolvedValue({ tools: [] });
+    StreamableTransportMock.mockReturnValue({});
+    await init({ m1: { serverUrl: "http://one" } as McpToolConfig });
+    const msgs = mockLog.mock.calls.map((c) => c[0].msg);
+    expect(msgs.some((m) => m.includes("MCP loaded for"))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- track per-server loading duration in `mcp.init()`
- report total MCP loading time via `log`
- cover new behaviour in `mcp.connect` tests

## Testing
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_6865a211cba8832c9b603ef911deb2e8