### PR TITLE
Init tools during startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { Message } from "telegraf/types";
 import { useConfig, validateConfig, watchConfigChanges } from "./config.ts";
 import { initCommands, handleAddChat } from "./commands.ts";
 import { log } from "./helpers.ts";
+import { initTools } from "./helpers/useTools.ts";
 import express from "express";
 import { useBot } from "./bot";
 import onTextMessage from "./handlers/onTextMessage.ts";
@@ -37,6 +38,9 @@ async function start() {
     process.exit(1);
   }
   watchConfigChanges();
+
+  // init global tools, including MCP functions
+  await initTools();
 
   try {
     await launchBot(config.auth.bot_token, config.bot_name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,9 +39,6 @@ async function start() {
   }
   watchConfigChanges();
 
-  // init global tools, including MCP functions
-  await initTools();
-
   try {
     await launchBot(config.auth.bot_token, config.bot_name);
     // log({msg: 'bot started'});
@@ -58,6 +55,7 @@ async function start() {
     // Initialize HTTP server
     initHttp();
     useMqtt();
+    await initTools();
   } catch (error: unknown) {
     console.error("Error during bot startup:", error);
     console.log("restart after 10 seconds...");

--- a/tests/index.start.test.ts
+++ b/tests/index.start.test.ts
@@ -153,7 +153,6 @@ describe("start", () => {
     await index.start();
 
     expect(setTimeoutSpy).toHaveBeenCalledWith(index.start, 10000);
-    expect(mockInitTools).toHaveBeenCalled();
     setTimeoutSpy.mockRestore();
   });
 });

--- a/tests/index.start.test.ts
+++ b/tests/index.start.test.ts
@@ -7,6 +7,7 @@ const mockUseMqtt = jest.fn();
 const mockUseBot = jest.fn();
 const mockInitCommands = jest.fn();
 const mockLog = jest.fn();
+const mockInitTools = jest.fn();
 
 const botInstance = {
   help: jest.fn(),
@@ -57,6 +58,12 @@ jest.unstable_mockModule("../src/commands.ts", () => ({
   handleAddChat: jest.fn(),
 }));
 
+jest.unstable_mockModule("../src/helpers/useTools.ts", () => ({
+  __esModule: true,
+  initTools: (...args: unknown[]) => mockInitTools(...args),
+  default: jest.fn(),
+}));
+
 jest.unstable_mockModule("../src/helpers.ts", () => ({
   __esModule: true,
   log: (...args: unknown[]) => mockLog(...args),
@@ -77,6 +84,7 @@ beforeEach(async () => {
   mockValidateConfig.mockReset();
   mockWatchConfigChanges.mockReset();
   mockUseMqtt.mockReset();
+  mockInitTools.mockReset();
 
   index = await import("../src/index.ts");
 });
@@ -107,6 +115,7 @@ describe("start", () => {
     await index.start();
 
     expect(mockWatchConfigChanges).toHaveBeenCalled();
+    expect(mockInitTools).toHaveBeenCalled();
     expect(mockUseBot).toHaveBeenCalledTimes(2);
     expect(expressApp.listen).toHaveBeenCalled();
     expect(mockUseMqtt).toHaveBeenCalled();
@@ -144,6 +153,7 @@ describe("start", () => {
     await index.start();
 
     expect(setTimeoutSpy).toHaveBeenCalledWith(index.start, 10000);
+    expect(mockInitTools).toHaveBeenCalled();
     setTimeoutSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- load tools when application starts
- expect initTools call in `start` tests

## Testing
- `npm run test-full`
- `npm run coverage-info`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6865a903f810832cb1fdb38134afe3d4