### PR TITLE
Add change access settings tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Telegram bot with functions tools.
 
 - `brainstorm` - Useful tool for brainstorming and planning task
 - `change_chat_settings` - Change chat settings in config.yml
+- `change_access_settings` - Update admin and private user lists in config.yml
 - `get_next_offday` - count 4-days cycle: day, night, sleep, offday
 - `javascript_interpreter` - exec JavaScript code
 - `obsidian_read` - return the contents of an Obsidian file specified by `file_path`, list of files pass to the prompt
@@ -113,7 +114,7 @@ Fetches content from a URL and inserts it into the prompt.
 systemMessage: |
   Here's the latest news:
   {url:https://example.com/breaking-news}
-  
+
   Summarize the key points above
 chatParams:
   placeholderCacheTime: 60
@@ -134,7 +135,7 @@ Executes a tool and inserts its output into the prompt.
 systemMessage: |
   Current weather:
   {tool:getWeather({"city": "London"})}
-  
+
   Based on this weather, what should I wear today?
 ```
 
@@ -284,15 +285,14 @@ chats:
   - name: "Chat with Evaluators"
     id: 123456789
     evaluators:
-      - agent_name: "url-checker"  # Name of the agent to use for evaluation
-        threshold: 4                   # Optional: minimum score to consider the response complete (default: 4)
-        maxIterations: 3              # Optional: maximum number of evaluation iterations (default: 3)
+      - agent_name: "url-checker" # Name of the agent to use for evaluation
+        threshold: 4 # Optional: minimum score to consider the response complete (default: 4)
+        maxIterations: 3 # Optional: maximum number of evaluation iterations (default: 3)
   - name: "URL evaluator agent"
     agent_name: "url-checker"
     systemMessage: "Check for url in answer."
     completionParams:
       model: "gpt-4.1-nano"
-    
 ```
 
 ### How Evaluators Are Used
@@ -311,6 +311,7 @@ To disable evaluators for a specific chat, simply omit the `evaluators` array fr
 - The `tools` list should include the names of tools (from MCP) that are available to that chat.
 
 Other useful chat parameters include:
+
 - `markOurUsers` – suffix to append to known users in history
 - `forgetTimeout` – auto-forget history after N seconds
 - Example chat config snippet:

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Telegram bot with functions tools.
 
 - `brainstorm` - Useful tool for brainstorming and planning task
 - `change_chat_settings` - Change chat settings in config.yml
-- `change_access_settings` - Update admin and private user lists in config.yml
+- `change_access_settings` - Add/remove users to admin and private user lists in config.yml
 - `get_next_offday` - count 4-days cycle: day, night, sleep, offday
+- `forget` - Forget chat history
 - `javascript_interpreter` - exec JavaScript code
 - `obsidian_read` - return the contents of an Obsidian file specified by `file_path`, list of files pass to the prompt
 - `obsidian_write` - append text to a markdown file specified by `out_file`

--- a/src/tools/change_access_settings.ts
+++ b/src/tools/change_access_settings.ts
@@ -1,0 +1,85 @@
+import { aiFunction, AIFunctionsProvider } from "@agentic/core";
+import { z } from "zod";
+import { readConfig, writeConfig } from "../config.ts";
+import { ConfigType, ToolResponse } from "../types.ts";
+
+type ToolArgsType = {
+  addAdmin?: string[];
+  removeAdmin?: string[];
+  addPrivate?: string[];
+  removePrivate?: string[];
+};
+
+export const description = "Update adminUsers and privateUsers in config.yml";
+export const details = `- Add or remove usernames from adminUsers and privateUsers`;
+
+export class ChangeAccessSettingsClient extends AIFunctionsProvider {
+  protected readonly config: ConfigType;
+  protected readonly details: string;
+
+  constructor() {
+    super();
+    this.config = readConfig();
+    this.details = details;
+  }
+
+  @aiFunction({
+    name: "change_access_settings",
+    description,
+    inputSchema: z.object({
+      addAdmin: z
+        .array(z.string())
+        .optional()
+        .describe("Usernames to add to adminUsers"),
+      removeAdmin: z
+        .array(z.string())
+        .optional()
+        .describe("Usernames to remove from adminUsers"),
+      addPrivate: z
+        .array(z.string())
+        .optional()
+        .describe("Usernames to add to privateUsers"),
+      removePrivate: z
+        .array(z.string())
+        .optional()
+        .describe("Usernames to remove from privateUsers"),
+    }),
+  })
+  async change_access_settings(options: ToolArgsType) {
+    const config = readConfig();
+    const admins = new Set(config.adminUsers || []);
+    const privates = new Set(config.privateUsers || []);
+
+    options.addAdmin?.forEach((u) => admins.add(u));
+    options.removeAdmin?.forEach((u) => admins.delete(u));
+    options.addPrivate?.forEach((u) => privates.add(u));
+    options.removePrivate?.forEach((u) => privates.delete(u));
+
+    config.adminUsers = Array.from(admins);
+    config.privateUsers = Array.from(privates);
+
+    writeConfig("config.yml", config);
+
+    return { content: "Access settings updated successfully" } as ToolResponse;
+  }
+
+  options_string(str: string) {
+    const opts = JSON.parse(str) as ToolArgsType;
+    if (!opts) return str;
+    const parts: string[] = [];
+    if (opts.addAdmin?.length)
+      parts.push(`addAdmin: ${opts.addAdmin.join(", ")}`);
+    if (opts.removeAdmin?.length)
+      parts.push(`removeAdmin: ${opts.removeAdmin.join(", ")}`);
+    if (opts.addPrivate?.length)
+      parts.push(`addPrivate: ${opts.addPrivate.join(", ")}`);
+    if (opts.removePrivate?.length)
+      parts.push(`removePrivate: ${opts.removePrivate.join(", ")}`);
+    if (!parts.length) return str;
+    return `**Change access:** \`${parts.join("; ")}\``;
+  }
+}
+
+export function call() {
+  return new ChangeAccessSettingsClient();
+}

--- a/tests/tools/change_access_settings.test.ts
+++ b/tests/tools/change_access_settings.test.ts
@@ -1,0 +1,63 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { ConfigType } from "../../src/types";
+
+const mockReadConfig = jest.fn();
+const mockWriteConfig = jest.fn();
+
+jest.unstable_mockModule("../../src/config.ts", () => ({
+  __esModule: true,
+  readConfig: () => mockReadConfig(),
+  writeConfig: (...args: unknown[]) => mockWriteConfig(...args),
+}));
+
+let mod: typeof import("../../src/tools/change_access_settings.ts");
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockReadConfig.mockReset();
+  mockWriteConfig.mockReset();
+  mod = await import("../../src/tools/change_access_settings.ts");
+});
+
+describe("ChangeAccessSettingsClient", () => {
+  function baseConfig(): ConfigType {
+    return {
+      bot_name: "bot",
+      auth: { bot_token: "", chatgpt_api_key: "" },
+      adminUsers: ["adm"],
+      privateUsers: ["p1"],
+      local_models: [],
+      http: {},
+      chats: [],
+    } as unknown as ConfigType;
+  }
+
+  it("updates admin and private users", async () => {
+    const config = baseConfig();
+    mockReadConfig.mockReturnValue(config);
+    const client = new mod.ChangeAccessSettingsClient();
+    const res = await client.change_access_settings({
+      addAdmin: ["new"],
+      removeAdmin: ["adm"],
+      addPrivate: ["p2"],
+    });
+    expect(res.content).toContain("updated");
+    expect(config.adminUsers).toEqual(["new"]);
+    expect(config.privateUsers).toEqual(["p1", "p2"]);
+    expect(mockWriteConfig).toHaveBeenCalledWith("config.yml", config);
+  });
+
+  it("options_string formats message", () => {
+    const client = new mod.ChangeAccessSettingsClient();
+    const str = client.options_string(
+      '{"addAdmin":["a"],"removePrivate":["b"]}',
+    );
+    expect(str).toBe("**Change access:** `addAdmin: a; removePrivate: b`");
+  });
+
+  it("call returns instance", () => {
+    expect(mod.call()).toBeInstanceOf(mod.ChangeAccessSettingsClient);
+  });
+});
+
+export {};


### PR DESCRIPTION
## Summary
- add `change_access_settings` tool to update user lists
- document the tool in README
- test change_access_settings tool

## Testing
- `npm run test-full`
- `npm run coverage-info`

------
https://chatgpt.com/codex/tasks/task_e_6865b0d166a8832c823244296e7fa103