### PR TITLE
Fix splitBigMessage to preserve blank lines

### DIFF
--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -3,11 +3,9 @@ export function splitBigMessage(text: string) {
   const sizeLimit = 4096;
   let msg = "";
 
-  for (const origLine of text.split("\n")) {
-    const line = origLine.trim();
-    if (!line) continue;
+  for (const line of text.split("\n")) {
     if (msg.length + line.length + 1 > sizeLimit) {
-      if (msg.trim()) msgs.push(msg);
+      if (msg) msgs.push(msg);
       msg = "";
     }
     msg += line + "\n";
@@ -15,6 +13,6 @@ export function splitBigMessage(text: string) {
   if (msg.length > sizeLimit) {
     msg = msg.slice(0, sizeLimit - 3) + "...";
   }
-  if (msg.trim()) msgs.push(msg);
+  if (msg) msgs.push(msg);
   return msgs;
 }

--- a/tests/utils/text.test.ts
+++ b/tests/utils/text.test.ts
@@ -17,4 +17,9 @@ describe("splitBigMessage", () => {
     expect(msg.length).toBe(4096);
     expect(msg.endsWith("...")).toBe(true);
   });
+
+  it("keeps blank lines", () => {
+    const res = splitBigMessage("a\n\nb");
+    expect(res).toEqual(["a\n\nb\n"]);
+  });
 });


### PR DESCRIPTION
## Summary
- keep original line content in `splitBigMessage`
- add unit test checking blank line preservation

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6867c1c9ddb4832c9ee15ee17be1de39