### PR TITLE
Fix markdown escaping for Telegram messages

### DIFF
--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -46,12 +46,12 @@ function sanitizeTelegramHtml(html: string): string {
 
 function telegramifyWithCodeBlocks(text: string): string {
   if (!text.includes("```")) {
-    return telegramifyMarkdown(text, "keep");
+    return telegramifyMarkdown(text, "escape");
   }
   return text
     .split(/(```[\s\S]*?```)/)
     .map((part) =>
-      part.startsWith("```") ? part : telegramifyMarkdown(part, "keep"),
+      part.startsWith("```") ? part : telegramifyMarkdown(part, "escape"),
     )
     .join("");
 }


### PR DESCRIPTION
## Summary
- ensure unsupported tags are escaped when sending Markdown messages

## Testing
- `npm run test-full`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_686e31e69a38832c90b7294f741bc637