### PR TITLE
Add web_search_preview tool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Telegram bot with functions tools.
 - `read_knowledge_google_sheet` - questions and answers from Google Sheet
 - `read_knowledge_json` - questions and answers from json file/url
 - `ssh_command` - exec ssh shell command, single server from config
+- `web_search_preview` - use OpenAI web search tool (Responses API)
 - ... and thousands of tools from MCP
 
 ## Config

--- a/tests/helpers/llm.extras.test.ts
+++ b/tests/helpers/llm.extras.test.ts
@@ -319,4 +319,22 @@ describe("requestGptAnswer", () => {
     expect(threads[1]).toBeDefined();
     expect(res).toEqual({ content: "a" });
   });
+
+  it("passes web_search_preview tool to API", async () => {
+    const api = {
+      responses: {
+        create: jest.fn().mockResolvedValue({ output_text: "r" }),
+      },
+    };
+    mockUseApi.mockReturnValue(api);
+    const msg: Message.TextMessage = { ...baseMsg };
+    await requestGptAnswer(msg, {
+      ...chatConfig,
+      tools: ["web_search_preview"],
+      local_model: undefined,
+      chatParams: { useResponsesApi: true },
+    });
+    const calledParams = (api.responses.create as jest.Mock).mock.calls[0][0];
+    expect(calledParams.tools).toEqual([{ type: "web_search_preview" }]);
+  });
 });


### PR DESCRIPTION
## Summary
- allow requesting OpenAI `web_search_preview` tool
- document search tool in README
- test passing of web_search_preview when using Responses API

## Testing
- `npm run format`
- `npm run typecheck`
- `npm run test-full`

------
https://chatgpt.com/codex/tasks/task_e_6873881feb88832c9c22e41ce5fedd85