### PR TITLE
Add streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,94 @@ Work only with OpenAI models.
 
 When enabled, the bot can use the `web_search_preview` tool to get web search results.
 
+## Streaming API responses
+
+Learn how to stream model responses from the OpenAI API using server-sent events.
+
+By default, when you make a request to the OpenAI API, we generate the model's entire output before sending it back in a single HTTP response. When generating long outputs, waiting for a response can take time. Streaming responses lets you start printing or processing the beginning of the model's output while it continues generating the full response.
+
+### Enable streaming
+
+To start streaming responses, set `stream=True` in your request to the Responses endpoint:
+
+```javascript
+import { OpenAI } from "openai";
+const client = new OpenAI();
+
+const stream = await client.responses.create({
+    model: "gpt-4.1",
+    input: [
+        {
+            role: "user",
+            content: "Say 'double bubble bath' ten times fast.",
+        },
+    ],
+    stream: true,
+});
+
+for await (const event of stream) {
+    console.log(event);
+}
+```
+
+The Responses API uses semantic events for streaming. Each event is typed with a predefined schema, so you can listen for events you care about.
+
+For a full list of event types, see the [API reference for streaming](/docs/api-reference/responses-streaming). Here are a few examples:
+
+```python
+type StreamingEvent = 
+| ResponseCreatedEvent
+| ResponseInProgressEvent
+| ResponseFailedEvent
+| ResponseCompletedEvent
+| ResponseOutputItemAdded
+| ResponseOutputItemDone
+| ResponseContentPartAdded
+| ResponseContentPartDone
+| ResponseOutputTextDelta
+| ResponseOutputTextAnnotationAdded
+| ResponseTextDone
+| ResponseRefusalDelta
+| ResponseRefusalDone
+| ResponseFunctionCallArgumentsDelta
+| ResponseFunctionCallArgumentsDone
+| ResponseFileSearchCallInProgress
+| ResponseFileSearchCallSearching
+| ResponseFileSearchCallCompleted
+| ResponseCodeInterpreterInProgress
+| ResponseCodeInterpreterCallCodeDelta
+| ResponseCodeInterpreterCallCodeDone
+| ResponseCodeInterpreterCallIntepreting
+| ResponseCodeInterpreterCallCompleted
+| Error
+```
+
+### Read the responses
+
+If you're using our SDK, every event is a typed instance. You can also identity individual events using the `type` property of the event.
+
+Some key lifecycle events are emitted only once, while others are emitted multiple times as the response is generated. Common events to listen for when streaming text are:
+
+```text
+- `response.created`
+- `response.output_text.delta`
+- `response.completed`
+- `error`
+```
+
+For a full list of events you can listen for, see the [API reference for streaming](/docs/api-reference/responses-streaming).
+
+### Advanced use cases
+
+For more advanced use cases, like streaming tool calls, check out the following dedicated guides:
+
+*   [Streaming function calls](/docs/guides/function-calling#streaming)
+*   [Streaming structured output](/docs/guides/structured-outputs#streaming)
+
+### Moderation risk
+
+Note that streaming the model's output in a production application makes it more difficult to moderate the content of the completions, as partial completions may be more difficult to evaluate. This may have implications for approved usage.
+
 ## Use agents as tools
 
 You can use one bot as a tool (agent) inside another bot. This allows you to compose complex workflows, delegate tasks, or chain multiple bots together.

--- a/src/config.ts
+++ b/src/config.ts
@@ -134,6 +134,7 @@ export function generateConfig(): ConfigType {
           confirmation: false,
           showToolMessages: true,
           useResponsesApi: false,
+          streaming: true,
         },
         toolParams: {
           brainstorm: {
@@ -177,6 +178,7 @@ export function generateConfig(): ConfigType {
           confirmation: false,
           showToolMessages: true,
           useResponsesApi: false,
+          streaming: true,
         },
         toolParams: {
           brainstorm: {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,7 +2,7 @@ import express from "express";
 import fs from "fs";
 import path from "path";
 
-type LogLevel = "debug" | "info" | "warn" | "error";
+type LogLevel = "debug" | "verbose" | "info" | "warn" | "error";
 
 interface LogParams {
   msg: string;

--- a/src/helpers/gpt/streaming.ts
+++ b/src/helpers/gpt/streaming.ts
@@ -1,0 +1,31 @@
+import OpenAI from "openai";
+import { log } from "../../helpers.ts";
+import { convertResponsesOutput } from "./responsesApi.ts";
+import type { ConfigChatType } from "../../types.ts";
+
+export async function handleResponseStream(
+  stream: AsyncIterable<{ type: string; response?: unknown }> & {
+    finalResponse(): Promise<OpenAI.Responses.Response>;
+  },
+  chatConfig?: ConfigChatType,
+): Promise<{ res: OpenAI.ChatCompletion; webSearchDetails?: string }> {
+  for await (const event of stream) {
+    log({
+      msg: `responses event: ${event.type}`,
+      chatId: chatConfig?.id,
+      chatTitle: chatConfig?.name,
+      logLevel: "debug",
+    });
+    if (event.type === "response.completed") {
+      log({
+        msg: `response.completed`,
+        chatId: chatConfig?.id,
+        chatTitle: chatConfig?.name,
+        logLevel: "info",
+      });
+    }
+  }
+
+  const response = (await stream.finalResponse()) as OpenAI.Responses.Response;
+  return convertResponsesOutput(response);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,7 @@ export type ChatParamsType = {
   markOurUsers?: string;
   placeholderCacheTime?: number;
   useResponsesApi?: boolean;
+  streaming?: boolean;
 };
 
 export type CompletionParamsType = {

--- a/tests/helpers/llm.extras.test.ts
+++ b/tests/helpers/llm.extras.test.ts
@@ -269,10 +269,9 @@ describe("llmCall", () => {
         for (const e of events)
           yield e as unknown as OpenAI.Responses.ResponseStreamEvent;
       },
-      finalResponse: jest.fn().mockResolvedValue(events[1].response),
       controller: { signal: undefined },
       on: jest.fn(),
-    } as unknown as OpenAI.Responses.ResponseStream<OpenAI.Responses.ResponseStreamEvent>;
+    } as unknown as AsyncIterable<OpenAI.Responses.ResponseStreamEvent>;
     const api = {
       responses: {
         stream: jest.fn().mockReturnValue(stream),

--- a/tests/helpers/llm.extras.test.ts
+++ b/tests/helpers/llm.extras.test.ts
@@ -135,7 +135,7 @@ describe("llmCall", () => {
       chatConfig: {
         ...chatConfig,
         local_model: undefined,
-        chatParams: { useResponsesApi: true },
+        chatParams: { useResponsesApi: true, streaming: false },
       },
     });
     const calledParams = (api.responses.create as jest.Mock).mock.calls[0][0];
@@ -191,7 +191,7 @@ describe("llmCall", () => {
       chatConfig: {
         ...chatConfig,
         local_model: undefined,
-        chatParams: { useResponsesApi: true },
+        chatParams: { useResponsesApi: true, streaming: false },
       },
     });
     expect(result.res.choices[0].message.tool_calls).toEqual([
@@ -235,7 +235,7 @@ describe("llmCall", () => {
       chatConfig: {
         ...chatConfig,
         local_model: undefined,
-        chatParams: { useResponsesApi: true },
+        chatParams: { useResponsesApi: true, streaming: false },
       },
     });
     const calledParams = (api.responses.create as jest.Mock).mock.calls[0][0];
@@ -248,6 +248,53 @@ describe("llmCall", () => {
       },
       { type: "function_call_output", call_id: "x", output: "res" },
     ]);
+  });
+
+  it("uses responses streaming when enabled", async () => {
+    mockUseLangfuse.mockReturnValue({ trace: undefined });
+    const events = [
+      {
+        type: "response.created",
+        sequence_number: 0,
+        response: { output: [], output_text: "" },
+      },
+      {
+        type: "response.completed",
+        sequence_number: 1,
+        response: { output_text: "r", output: [] },
+      },
+    ];
+    const stream = {
+      async *[Symbol.asyncIterator]() {
+        for (const e of events)
+          yield e as unknown as OpenAI.Responses.ResponseStreamEvent;
+      },
+      finalResponse: jest.fn().mockResolvedValue(events[1].response),
+      controller: { signal: undefined },
+      on: jest.fn(),
+    } as unknown as OpenAI.Responses.ResponseStream<OpenAI.Responses.ResponseStreamEvent>;
+    const api = {
+      responses: {
+        stream: jest.fn().mockReturnValue(stream),
+        create: jest.fn(),
+      },
+    };
+    mockUseApi.mockReturnValue(api);
+    const params = {
+      messages: [{ role: "user", content: "hi" }],
+      model: "m",
+    } as OpenAI.ChatCompletionCreateParams;
+    const result = await llm.llmCall({
+      apiParams: params,
+      msg: { ...baseMsg },
+      chatConfig: {
+        ...chatConfig,
+        local_model: undefined,
+        chatParams: { useResponsesApi: true, streaming: true },
+      },
+    });
+    expect(api.responses.stream).toHaveBeenCalled();
+    expect(result.res.choices[0].message.content).toBe("r");
   });
 });
 
@@ -332,7 +379,7 @@ describe("requestGptAnswer", () => {
       ...chatConfig,
       tools: ["web_search_preview"],
       local_model: undefined,
-      chatParams: { useResponsesApi: true },
+      chatParams: { useResponsesApi: true, streaming: false },
     });
     const calledParams = (api.responses.create as jest.Mock).mock.calls[0][0];
     expect(calledParams.tools).toEqual([{ type: "web_search_preview" }]);
@@ -372,7 +419,7 @@ describe("requestGptAnswer", () => {
       ...chatConfig,
       tools: ["web_search_preview"],
       local_model: undefined,
-      chatParams: { useResponsesApi: true },
+      chatParams: { useResponsesApi: true, streaming: false },
     });
     const sent = (await import("../../src/telegram/send.ts"))
       .sendTelegramMessage as jest.Mock;

--- a/tests/helpers/responsesApi.test.ts
+++ b/tests/helpers/responsesApi.test.ts
@@ -86,6 +86,19 @@ describe("responsesApi helpers", () => {
     expect(res.choices[0].message.content).toBe("hello");
   });
 
+  it("uses message output when output_text missing", () => {
+    const r: OpenAI.Responses.Response = {
+      output: [
+        {
+          type: "message",
+          content: [{ type: "output_text", text: "msg" }],
+        },
+      ],
+    } as unknown as OpenAI.Responses.Response;
+    const { res } = convertResponsesOutput(r);
+    expect(res.choices[0].message.content).toBe("msg");
+  });
+
   it("parses web search details", () => {
     const r: OpenAI.Responses.Response = {
       output_text: "hi",


### PR DESCRIPTION
## Summary
- support streaming for OpenAI Responses API
- extend `ChatParams` with `streaming` option
- default config now enables streaming
- log streaming events in new `handleResponseStream`
- document streaming usage in README
- test streaming behaviour in `llmCall`

## Testing
- `npm run format`
- `npm run typecheck`
- `npm run test-full`
- `npm run coverage-info`

------
https://chatgpt.com/codex/tasks/task_e_687416e8be28832c81ad184a44d8feef