### PR TITLE
Add image_generation tool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Telegram bot with functions tools.
 - `read_knowledge_json` - questions and answers from json file/url
 - `ssh_command` - exec ssh shell command, single server from config
 - `web_search_preview` - use OpenAI internal web search tool (only for Responses API)
+- `image_generation` - generate images using OpenAI image model (only for Responses API)
 - ... and thousands of tools from MCP
 
 ## Config
@@ -150,6 +151,7 @@ To use it, set `useResponsesApi` to `true` in the chat config.
 Work only with OpenAI models.
 
 When enabled, the bot can use the `web_search_preview` tool to get web search results.
+It can also generate images using the `image_generation` tool.
 
 ## Streaming API responses
 

--- a/src/helpers/gpt/streaming.ts
+++ b/src/helpers/gpt/streaming.ts
@@ -6,7 +6,11 @@ import type { ConfigChatType } from "../../types.ts";
 export async function handleResponseStream(
   stream: AsyncIterable<{ type: string; response?: unknown }>,
   chatConfig?: ConfigChatType,
-): Promise<{ res: OpenAI.ChatCompletion; webSearchDetails?: string }> {
+): Promise<{
+  res: OpenAI.ChatCompletion;
+  webSearchDetails?: string;
+  images?: { id?: string; result: string }[];
+}> {
   let completed: OpenAI.Responses.Response | undefined;
   for await (const event of stream) {
     log({

--- a/tests/helpers/responsesApi.test.ts
+++ b/tests/helpers/responsesApi.test.ts
@@ -128,4 +128,21 @@ describe("responsesApi helpers", () => {
     expect(webSearchDetails).toContain("Web search:");
     expect(webSearchDetails).toContain("[T](https://u) (opened)");
   });
+
+  it("returns image generation data", () => {
+    const r: OpenAI.Responses.Response = {
+      output_text: "img",
+      output: [
+        {
+          id: "img_1",
+          type: "image_generation_call",
+          status: "completed",
+          result: "abcd",
+        },
+      ],
+    } as unknown as OpenAI.Responses.Response;
+    const { res, images } = convertResponsesOutput(r);
+    expect(res.choices[0].message.content).toBe("img");
+    expect(images?.[0].result).toBe("abcd");
+  });
 });


### PR DESCRIPTION
## Summary
- support `image_generation` tool for Responses API
- parse image generation results and send images
- document image generation tool
- test conversion and API calls

## Testing
- `npm run format`
- `npx tsc --noEmit --pretty false`
- `npm run test-full`
- `npm run coverage-info`

------
https://chatgpt.com/codex/tasks/task_e_6874cff8bb94832ca6066786a025996b