### PR TITLE
Fix noisy test output

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,6 @@ const config = {
       'ts-jest',
       {
         useESM: true,
-        isolatedModules: true,
         tsconfig: 'tsconfig.json',
       },
     ],

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -12,6 +12,7 @@ beforeEach(async () => {
   console.error = jestObj.fn();
   console.warn = jestObj.fn();
   console.info = jestObj.fn();
+  console.debug = jestObj.fn();
 });
 
 afterEach(() => {
@@ -19,6 +20,7 @@ afterEach(() => {
   console.error = originalConsole.error;
   console.warn = originalConsole.warn;
   console.info = originalConsole.info;
+  console.debug = originalConsole.debug;
 });
 
 export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "allowImportingTsExtensions": true,
     "esModuleInterop": true,
+    "isolatedModules": true,
     "noEmit": true,
     "typeRoots": ["node_modules/@types", "src/@types"]
   },


### PR DESCRIPTION
## Summary
- enable `isolatedModules` in `tsconfig.json`
- remove deprecated option from Jest config
- mute `console.debug` in tests

## Testing
- `npm run test-full`

------
https://chatgpt.com/codex/tasks/task_e_6874defaf268832cb9873e69a7360f0c