### PR TITLE
Refactor streaming logic

### DIFF
--- a/src/helpers/gpt/llm.ts
+++ b/src/helpers/gpt/llm.ts
@@ -34,7 +34,7 @@ import {
 } from "./responsesApi.ts";
 import {
   handleResponseStream,
-  handleChatCompletionStream,
+  handleCompletionStream,
 } from "./streaming.ts";
 import type { ChatCompletionStream } from "openai/lib/ChatCompletionStream.js";
 
@@ -118,7 +118,7 @@ export async function llmCall({
           ) => ChatCompletionStream;
         };
         const streamObj = stream({ ...apiParams, stream: true }, { signal });
-        const { res, sentMessages } = await handleChatCompletionStream(
+        const { res, sentMessages } = await handleCompletionStream(
           streamObj,
           msg,
           chatConfig,

--- a/src/helpers/gpt/streaming.ts
+++ b/src/helpers/gpt/streaming.ts
@@ -6,6 +6,180 @@ import { useBot } from "../../bot.ts";
 import { splitBigMessage } from "../../utils/text.ts";
 import telegramifyMarkdown from "telegramify-markdown";
 
+export function getRetryAfter(error: unknown) {
+  const e = error as {
+    response?: { error_code?: number; parameters?: { retry_after?: number } };
+  };
+  if (e?.response?.error_code === 429 && e.response.parameters?.retry_after) {
+    return e.response.parameters.retry_after * 1000;
+  }
+  return undefined;
+}
+
+export async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function safeSend(
+  bot: ReturnType<typeof useBot>,
+  chatId: number | string,
+  text: string,
+): Promise<Message.TextMessage> {
+  for (;;) {
+    try {
+      return (await bot.telegram.sendMessage(
+        chatId,
+        text,
+      )) as Message.TextMessage;
+    } catch (err) {
+      const wait = getRetryAfter(err);
+      if (wait) {
+        await delay(wait);
+        continue;
+      }
+      console.warn("sendMessage failed", err);
+      throw err;
+    }
+  }
+}
+
+export async function safeEdit(
+  bot: ReturnType<typeof useBot>,
+  m: Message.TextMessage,
+  text: string,
+): Promise<void> {
+  for (;;) {
+    try {
+      await bot.telegram.editMessageText(
+        m.chat.id,
+        m.message_id,
+        undefined,
+        text,
+      );
+      return;
+    } catch (err) {
+      const wait = getRetryAfter(err);
+      if (wait) {
+        await delay(wait);
+        continue;
+      }
+      console.warn("editMessageText failed", err);
+      return;
+    }
+  }
+}
+
+export async function safeDelete(
+  bot: ReturnType<typeof useBot>,
+  m: Message.TextMessage,
+): Promise<void> {
+  for (;;) {
+    try {
+      await bot.telegram.deleteMessage(m.chat.id, m.message_id);
+      return;
+    } catch (err) {
+      const wait = getRetryAfter(err);
+      if (wait) {
+        await delay(wait);
+        continue;
+      }
+      console.warn("deleteMessage failed", err);
+      return;
+    }
+  }
+}
+
+function createFlusher(
+  bot: ReturnType<typeof useBot>,
+  msg: Message.TextMessage,
+) {
+  const sentMessages: Message.TextMessage[] = [];
+  const lastChunks: string[] = [];
+  let fullText = "";
+  let flushTimeout: NodeJS.Timeout | undefined;
+  let processing = true;
+
+  async function sendChunks(text: string) {
+    const chunks = splitBigMessage(text);
+    for (let i = 0; i < chunks.length; i++) {
+      if (lastChunks[i] === chunks[i]) continue;
+      lastChunks[i] = chunks[i];
+      if (!sentMessages[i]) {
+        sentMessages[i] = await safeSend(bot, msg.chat.id, chunks[i]);
+      } else {
+        await safeEdit(bot, sentMessages[i], chunks[i]);
+      }
+    }
+  }
+
+  async function flush() {
+    await sendChunks(fullText);
+  }
+
+  function scheduleFlush() {
+    if (flushTimeout) return;
+    flushTimeout = setTimeout(async () => {
+      flushTimeout = undefined;
+      await flush();
+      if (processing) scheduleFlush();
+    }, 2000);
+  }
+
+  function add(delta: string) {
+    fullText += delta;
+    scheduleFlush();
+  }
+
+  async function finish() {
+    processing = false;
+    if (flushTimeout) {
+      clearTimeout(flushTimeout);
+      flushTimeout = undefined;
+    }
+    await flush();
+    return { fullText, sentMessages } as const;
+  }
+
+  return { add, finish, sentMessages } as const;
+}
+
+export async function handleStream<T, R>(
+  stream: AsyncIterable<T>,
+  msg: Message.TextMessage,
+  chatConfig: ConfigChatType | undefined,
+  callbacks: {
+    extractDelta(chunk: T): string | undefined;
+    onChunk?(chunk: T): void;
+    finalize(
+      fullText: string,
+      helpers: {
+        sentMessages: Message.TextMessage[];
+        safeEdit: (m: Message.TextMessage, t: string) => Promise<void>;
+        safeDelete: (m: Message.TextMessage) => Promise<void>;
+      },
+    ): Promise<R>;
+  },
+): Promise<R & { sentMessages: Message.TextMessage[] }> {
+  const bot = useBot(chatConfig?.bot_token);
+  const flusher = createFlusher(bot, msg);
+
+  for await (const chunk of stream) {
+    callbacks.onChunk?.(chunk);
+    const delta = callbacks.extractDelta(chunk);
+    if (delta) flusher.add(delta);
+  }
+
+  const { fullText, sentMessages } = await flusher.finish();
+
+  const res = await callbacks.finalize(fullText, {
+    sentMessages,
+    safeEdit: (m, t) => safeEdit(bot, m, t),
+    safeDelete: (m) => safeDelete(bot, m),
+  });
+
+  return { ...res, sentMessages };
+}
+
 export async function handleResponseStream(
   stream: AsyncIterable<OpenAI.Responses.ResponseStreamEvent>,
   msg: Message.TextMessage,
@@ -17,129 +191,33 @@ export async function handleResponseStream(
   sentMessages: Message.TextMessage[];
 }> {
   let completed: OpenAI.Responses.Response | undefined;
-  const sentMessages: Message.TextMessage[] = [];
-  const lastChunks: string[] = [];
-  let fullText = "";
-  const bot = useBot(chatConfig?.bot_token);
 
-  async function delay(ms: number) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  }
-
-  function getRetryAfter(error: unknown) {
-    const e = error as {
-      response?: { error_code?: number; parameters?: { retry_after?: number } };
-    };
-    if (e?.response?.error_code === 429 && e.response.parameters?.retry_after) {
-      return e.response.parameters.retry_after * 1000;
-    }
-    return undefined;
-  }
-
-  async function safeSend(text: string) {
-    for (;;) {
-      try {
-        return (await bot.telegram.sendMessage(
-          msg.chat.id,
-          text,
-        )) as Message.TextMessage;
-      } catch (err) {
-        const wait = getRetryAfter(err);
-        if (wait) {
-          await delay(wait);
-          continue;
-        }
-        console.warn("sendMessage failed", err);
-        throw err;
+  return handleStream(stream, msg, chatConfig, {
+    extractDelta(chunk) {
+      return chunk.type === "response.output_text.delta"
+        ? (chunk as OpenAI.Responses.ResponseTextDeltaEvent).delta
+        : undefined;
+    },
+    onChunk(chunk) {
+      if (chunk.type === "response.completed") {
+        completed = (chunk as OpenAI.Responses.ResponseCompletedEvent).response;
       }
-    }
-  }
-
-  async function safeEdit(m: Message.TextMessage, text: string) {
-    for (;;) {
-      try {
-        await bot.telegram.editMessageText(
-          m.chat.id,
-          m.message_id,
-          undefined,
-          text,
-        );
-        return;
-      } catch (err) {
-        const wait = getRetryAfter(err);
-        if (wait) {
-          await delay(wait);
-          continue;
-        }
-        console.warn("editMessageText failed", err);
-        return;
+    },
+    async finalize(_fullText, helpers) {
+      if (!completed) {
+        throw new Error("No response.completed event received");
       }
-    }
-  }
-
-  async function sendChunks(text: string) {
-    const chunks = splitBigMessage(text);
-    for (let i = 0; i < chunks.length; i++) {
-      if (lastChunks[i] === chunks[i]) continue;
-      lastChunks[i] = chunks[i];
-      if (!sentMessages[i]) {
-        sentMessages[i] = await safeSend(chunks[i]);
-      } else {
-        await safeEdit(sentMessages[i], chunks[i]);
-      }
-    }
-  }
-
-  let flushTimeout: NodeJS.Timeout | undefined;
-  let processing = true;
-
-  async function flush() {
-    await sendChunks(fullText);
-  }
-
-  function scheduleFlush() {
-    if (flushTimeout) return;
-    flushTimeout = setTimeout(async () => {
-      flushTimeout = undefined;
-      await flush();
-      if (processing) scheduleFlush();
-    }, 2000);
-  }
-
-  scheduleFlush();
-
-  for await (const event of stream) {
-    console.debug("stream event", event.type);
-    if (event.type === "response.output_text.delta") {
-      const delta = event as OpenAI.Responses.ResponseTextDeltaEvent;
-      fullText += delta.delta;
-      scheduleFlush();
-    } else if (event.type === "response.completed") {
-      completed = event.response as OpenAI.Responses.Response;
-    }
-  }
-
-  processing = false;
-  if (flushTimeout) {
-    clearTimeout(flushTimeout);
-    flushTimeout = undefined;
-  }
-  await flush();
-
-  if (!completed) {
-    throw new Error("No response.completed event received");
-  }
-
-  const result = await convertResponsesOutput(completed, {
-    sentMessages,
-    chatConfig,
+      return convertResponsesOutput(completed, {
+        sentMessages: helpers.sentMessages,
+        chatConfig,
+      });
+    },
   });
-  return { ...result, sentMessages };
 }
 
 import type { ChatCompletionStream } from "openai/lib/ChatCompletionStream.js";
 
-export async function handleChatCompletionStream(
+export async function handleCompletionStream(
   stream: ChatCompletionStream,
   msg: Message.TextMessage,
   chatConfig?: ConfigChatType,
@@ -147,176 +225,60 @@ export async function handleChatCompletionStream(
   res: OpenAI.ChatCompletion;
   sentMessages: Message.TextMessage[];
 }> {
-  const sentMessages: Message.TextMessage[] = [];
-  const lastChunks: string[] = [];
-  let fullText = "";
-  const bot = useBot(chatConfig?.bot_token);
-
-  async function delay(ms: number) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  }
-
-  function getRetryAfter(error: unknown) {
-    const e = error as {
-      response?: { error_code?: number; parameters?: { retry_after?: number } };
-    };
-    if (e?.response?.error_code === 429 && e.response.parameters?.retry_after) {
-      return e.response.parameters.retry_after * 1000;
-    }
-    return undefined;
-  }
-
-  async function safeSend(text: string) {
-    for (;;) {
-      try {
-        return (await bot.telegram.sendMessage(
-          msg.chat.id,
-          text,
-        )) as Message.TextMessage;
-      } catch (err) {
-        const wait = getRetryAfter(err);
-        if (wait) {
-          await delay(wait);
-          continue;
-        }
-        console.warn("sendMessage failed", err);
-        throw err;
-      }
-    }
-  }
-
-  async function safeEdit(m: Message.TextMessage, text: string) {
-    for (;;) {
-      try {
-        await bot.telegram.editMessageText(
-          m.chat.id,
-          m.message_id,
-          undefined,
-          text,
-        );
-        return;
-      } catch (err) {
-        const wait = getRetryAfter(err);
-        if (wait) {
-          await delay(wait);
-          continue;
-        }
-        console.warn("editMessageText failed", err);
-        return;
-      }
-    }
-  }
-
-  async function safeDelete(m: Message.TextMessage) {
-    for (;;) {
-      try {
-        await bot.telegram.deleteMessage(m.chat.id, m.message_id);
-        return;
-      } catch (err) {
-        const wait = getRetryAfter(err);
-        if (wait) {
-          await delay(wait);
-          continue;
-        }
-        console.warn("deleteMessage failed", err);
-        return;
-      }
-    }
-  }
-
-  async function sendChunks(text: string) {
-    const chunks = splitBigMessage(text);
-    for (let i = 0; i < chunks.length; i++) {
-      if (lastChunks[i] === chunks[i]) continue;
-      lastChunks[i] = chunks[i];
-      if (!sentMessages[i]) {
-        sentMessages[i] = await safeSend(chunks[i]);
+  return handleStream(stream, msg, chatConfig, {
+    extractDelta(chunk) {
+      return (chunk as any).choices?.[0]?.delta?.content;
+    },
+    async finalize(fullText, helpers) {
+      let res: OpenAI.ChatCompletion;
+      let finalOutput = "";
+      if (typeof (stream as any).finalChatCompletion === "function") {
+        res = await (
+          stream as unknown as {
+            finalChatCompletion(): Promise<OpenAI.ChatCompletion>;
+          }
+        ).finalChatCompletion();
+        finalOutput = res.choices?.[0]?.message?.content ?? "";
+      } else if (typeof (stream as any).finalMessage === "function") {
+        const message = await (stream as any).finalMessage();
+        res = { choices: [{ index: 0, message }] } as OpenAI.ChatCompletion;
+        finalOutput = message?.content ?? "";
+      } else if (typeof (stream as any).finalContent === "function") {
+        const content = await (stream as any).finalContent();
+        res = {
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: content ?? "" },
+            } as OpenAI.ChatCompletion.Choice,
+          ],
+        } as OpenAI.ChatCompletion;
+        finalOutput = content ?? "";
       } else {
-        await safeEdit(sentMessages[i], chunks[i]);
+        res = {
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: fullText },
+            } as OpenAI.ChatCompletion.Choice,
+          ],
+        } as OpenAI.ChatCompletion;
+        finalOutput = fullText;
       }
-    }
-  }
 
-  let flushTimeout: NodeJS.Timeout | undefined;
-  let processing = true;
-
-  async function flush() {
-    await sendChunks(fullText);
-  }
-
-  function scheduleFlush() {
-    if (flushTimeout) return;
-    flushTimeout = setTimeout(async () => {
-      flushTimeout = undefined;
-      await flush();
-      if (processing) scheduleFlush();
-    }, 2000);
-  }
-
-  scheduleFlush();
-
-  for await (const chunk of stream) {
-    const delta = chunk.choices?.[0]?.delta?.content;
-    if (delta) {
-      fullText += delta;
-      scheduleFlush();
-    }
-  }
-
-  processing = false;
-  if (flushTimeout) {
-    clearTimeout(flushTimeout);
-    flushTimeout = undefined;
-  }
-  await flush();
-
-  let res: OpenAI.ChatCompletion;
-  let finalOutput = "";
-  if (typeof (stream as any).finalChatCompletion === "function") {
-    res = await (
-      stream as unknown as {
-        finalChatCompletion(): Promise<OpenAI.ChatCompletion>;
+      const processed = telegramifyMarkdown(finalOutput, "escape");
+      const chunks = splitBigMessage(processed);
+      for (let i = 0; i < chunks.length; i++) {
+        if (helpers.sentMessages[i]) {
+          await helpers.safeEdit(helpers.sentMessages[i], chunks[i]);
+        }
       }
-    ).finalChatCompletion();
-    finalOutput = res.choices?.[0]?.message?.content ?? "";
-  } else if (typeof (stream as any).finalMessage === "function") {
-    const message = await (stream as any).finalMessage();
-    res = { choices: [{ index: 0, message }] } as OpenAI.ChatCompletion;
-    finalOutput = message?.content ?? "";
-  } else if (typeof (stream as any).finalContent === "function") {
-    const content = await (stream as any).finalContent();
-    res = {
-      choices: [
-        {
-          index: 0,
-          message: { role: "assistant", content: content ?? "" },
-        } as OpenAI.ChatCompletion.Choice,
-      ],
-    } as OpenAI.ChatCompletion;
-    finalOutput = content ?? "";
-  } else {
-    res = {
-      choices: [
-        {
-          index: 0,
-          message: { role: "assistant", content: fullText },
-        } as OpenAI.ChatCompletion.Choice,
-      ],
-    } as OpenAI.ChatCompletion;
-    finalOutput = fullText;
-  }
+      for (const m of helpers.sentMessages) {
+        await helpers.safeDelete(m);
+      }
+      helpers.sentMessages.length = 0;
 
-  const processed = telegramifyMarkdown(finalOutput, "escape");
-  const chunks = splitBigMessage(processed);
-  for (let i = 0; i < chunks.length; i++) {
-    if (sentMessages[i]) {
-      await safeEdit(sentMessages[i], chunks[i]);
-    }
-  }
-  for (const m of sentMessages) {
-    await safeDelete(m);
-  }
-  sentMessages.length = 0;
-
-  return { res, sentMessages };
+      return { res };
+    },
+  });
 }


### PR DESCRIPTION
## Summary
- refactor streaming helpers into generic functions
- unify response/completion streaming through `handleStream`

## Testing
- `npm run test-full`
- `npm run coverage-info`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68755d1ff870832c9cf222cdc964a7b5