### PR TITLE
Add case-insensitive user checks

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -18,6 +18,7 @@ import {
 import { forgetHistory } from "./helpers/history.ts";
 import { commandGoogleOauth } from "./helpers/google.ts";
 import useTools from "./helpers/useTools.ts";
+import { includesUser } from "./utils/users.ts";
 
 export async function handleForget(ctx: Context) {
   forgetHistory(ctx.chat!.id);
@@ -111,7 +112,7 @@ export async function commandAddTool(
         // check admin
         const { user } = getActionUserMsg(ctx);
         const username = user?.username || "without_username";
-        if (!user || !config.adminUsers?.includes(username)) return;
+        if (!user || !includesUser(config.adminUsers, username)) return;
 
         let chatConfig: ConfigChatType | undefined;
         if (ctx.chat?.type === "private") {
@@ -193,7 +194,8 @@ export async function getToolsInfo(
 
     // check access when privateUsers is set
     if (agentConfig.privateUsers) {
-      const isPrivateUser = agentConfig.privateUsers.includes(
+      const isPrivateUser = includesUser(
+        agentConfig.privateUsers,
         msg.from?.username || "without_username",
       );
       if (!isPrivateUser) return false;

--- a/src/helpers/gpt/tools.ts
+++ b/src/helpers/gpt/tools.ts
@@ -18,6 +18,7 @@ import useLangfuse from "../useLangfuse.ts";
 import { isAdminUser } from "../../telegram/send.ts";
 import { useConfig } from "../../config.ts";
 import { requestGptAnswer } from "./llm.ts";
+import { includesUser } from "../../utils/users.ts";
 import { publishMqttProgress } from "../../mqtt.ts";
 
 export function prettifyKeyValue(
@@ -496,7 +497,8 @@ export async function resolveChatTools(
       );
       if (!agentConfig) return false;
       if (agentConfig.privateUsers) {
-        const isPrivateUser = agentConfig.privateUsers.includes(
+        const isPrivateUser = includesUser(
+          agentConfig.privateUsers,
           msg.from?.username || "without_username",
         );
         if (!isPrivateUser) return false;

--- a/src/telegram/context.ts
+++ b/src/telegram/context.ts
@@ -3,6 +3,7 @@ import { Context } from "telegraf";
 import { User } from "@telegraf/types/manage";
 import { useConfig } from "../config.ts";
 import { log } from "../helpers.ts";
+import { includesUser } from "../utils/users.ts";
 import {
   ChatParamsType,
   CompletionParamsType,
@@ -16,7 +17,7 @@ function isAccessAllowed(chatConfig: ConfigChatType, ctxChat: Chat) {
     ...(useConfig().adminUsers ?? []),
   ];
   const username = privateChat.username || "without_username";
-  return allowedUsers.includes(username);
+  return includesUser(allowedUsers, username);
 }
 
 function getChatConfig(

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -1,6 +1,7 @@
 import { Message } from "telegraf/types";
 import { useBot } from "../bot.ts";
 import { useConfig } from "../config.ts";
+import { includesUser } from "../utils/users.ts";
 import { ConfigChatButtonType, ConfigChatType } from "../types.ts";
 import { Context, Markup, Input } from "telegraf";
 import { User } from "@telegraf/types/manage";
@@ -208,7 +209,7 @@ export async function sendTelegramMessage(
 
 export function isAdminUser(msg: Message.TextMessage): boolean {
   if (!msg.from?.username) return false;
-  return (useConfig().adminUsers || []).includes(msg.from.username);
+  return includesUser(useConfig().adminUsers, msg.from.username);
 }
 
 export function buildButtonRows(buttons: ConfigChatButtonType[]) {
@@ -252,9 +253,14 @@ export function isOurUser(
   const chatPrivateUsers = chatConfig?.privateUsers || [];
   const isOurUser =
     username &&
-    [chatPrivateUsers, useConfig().privateUsers, useConfig().adminUsers]
-      .flat()
-      .includes(username);
+    includesUser(
+      [
+        ...chatPrivateUsers,
+        ...(useConfig().privateUsers || []),
+        ...(useConfig().adminUsers || []),
+      ],
+      username,
+    );
   return isOurUser;
 }
 

--- a/src/utils/users.ts
+++ b/src/utils/users.ts
@@ -1,0 +1,8 @@
+export function includesUser(
+  list: readonly string[] | undefined,
+  username: string | undefined,
+): boolean {
+  if (!username || !list) return false;
+  const name = username.toLowerCase();
+  return list.some((u) => u.toLowerCase() === name);
+}

--- a/tests/telegram/context.test.ts
+++ b/tests/telegram/context.test.ts
@@ -77,6 +77,16 @@ describe("getCtxChatMsg", () => {
     expect(msg?.text).toBe("hi");
   });
 
+  it("ignores case when checking private users", () => {
+    mockUseConfig.mockReturnValue({
+      chats: [{ ...baseChat, privateUsers: ["User"] }],
+      privateUsers: [],
+    });
+    const ctx = createCtx({ message: createMsg("user") });
+    const { chat } = getCtxChatMsg(ctx);
+    expect(chat).toMatchObject(baseChat);
+  });
+
   it("returns undefined chat when user not allowed", () => {
     mockUseConfig.mockReturnValue({
       chats: [{ ...baseChat, privateUsers: ["other"] }],

--- a/tests/telegram/send.test.ts
+++ b/tests/telegram/send.test.ts
@@ -31,6 +31,13 @@ describe("isAdminUser", () => {
     expect(isAdminUser(msg)).toBe(false);
   });
 
+  it("ignores case", () => {
+    const msg = {
+      from: { username: "AdMiN" },
+    } as unknown as Message.TextMessage;
+    expect(isAdminUser(msg)).toBe(true);
+  });
+
   it("returns false when username missing", () => {
     const msg = { from: {} } as unknown as Message.TextMessage;
     expect(isAdminUser(msg)).toBe(false);


### PR DESCRIPTION
## Summary
- add `includesUser` helper for case-insensitive username search
- use it when checking admin and private user lists
- update tests for new behaviour

## Testing
- `npm run test-full`
- `npm run coverage-info`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6877e25eda30832cbd9491184d12bf34