### PR TITLE
Improve bot error handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,10 @@ import {
 import { useMqtt } from "./mqtt.ts";
 import { healthHandler } from "./healthcheck.ts";
 
+process.on("unhandledRejection", (reason) => {
+  log({ msg: `Unhandled rejection: ${reason}`, logLevel: "error" });
+});
+
 process.on("uncaughtException", (error, source) => {
   console.log("Uncaught Exception:", error);
   console.log("source:", source);
@@ -84,6 +88,15 @@ async function launchBot(bot_token: string, bot_name: string) {
     bot.on(message("video"), onUnsupported);
     bot.on(message("video_note"), onUnsupported);
     bot.on(message("document"), onUnsupported);
+
+    if ("catch" in bot && typeof (bot as any).catch === "function") {
+      bot.catch((err, ctx) => {
+        log({
+          msg: `[${bot_name}] Unhandled error for update ${ctx.update.update_id}: ${err instanceof Error ? err.message : String(err)}`,
+          logLevel: "error",
+        });
+      });
+    }
 
     // Set up chat action handler
     bot.action("add_chat", handleAddChat);


### PR DESCRIPTION
## Summary
- handle unhandled promise rejections globally
- catch Telegraf errors to prevent crashes

## Testing
- `npm run format`
- `npm run typecheck`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_6887581a13ec832cb4019ff8cc5fb2da