### PR TITLE
Fix launchBot mock objects in tests

### DIFF
--- a/tests/index.start.test.ts
+++ b/tests/index.start.test.ts
@@ -13,6 +13,7 @@ const botInstance = {
   help: jest.fn(),
   on: jest.fn(),
   action: jest.fn(),
+  catch: jest.fn(),
   launch: jest.fn().mockResolvedValue(undefined),
   botInfo: { username: "bot" },
 };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -110,6 +110,7 @@ beforeEach(async () => {
     help: jest.fn(),
     on: jest.fn(),
     action: jest.fn(),
+    catch: jest.fn(),
     launch: jest.fn().mockResolvedValue(undefined),
   });
   mockInitCommands.mockReset();


### PR DESCRIPTION
## Summary
- add `catch` stub to bot mocks in `index.test.ts` and `index.start.test.ts`

## Testing
- `npm run typecheck`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_6887c0dbef50832ca1e6dbbcaf250a4e