### PR TITLE
Add deeplink vars support

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -167,6 +167,13 @@ export function generateConfig(): ConfigType {
           sheetName: "sheet_name",
         },
         buttonsSynced: [{ name: "button_name", prompt: "button_prompt" }],
+        deeplinks: [{ name: "from" }],
+        user_vars: [
+          {
+            username: "myuser",
+            vars: { from: "popstas" },
+          },
+        ],
         http_token: "change_me",
         tools: ["javascript_interpreter", "brainstorm", "fetch"],
         evaluators: [

--- a/src/helpers/placeholders.ts
+++ b/src/helpers/placeholders.ts
@@ -105,6 +105,21 @@ export function __clearToolCache() {
   }
 }
 
+export function replaceVarsPlaceholders(
+  text: string,
+  vars: Record<string, string>,
+) {
+  text = text.replace(
+    /<vars:([^>]+)>([\s\S]*?)<\/vars:\1>/g,
+    (_, name, content) => {
+      const val = vars[name];
+      if (val === undefined) return "";
+      return content.replace(new RegExp(`{vars:${name}}`, "g"), val);
+    },
+  );
+  return text.replace(/\{vars:([^}]+)}/g, (_, name) => vars[name] || "");
+}
+
 // For tests
 export function __clearUrlCache() {
   for (const key of Object.keys(urlCache)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,8 @@ export type ConfigChatType = {
   buttons?: ConfigChatButtonType[];
   buttonsSync?: ButtonsSyncConfigType;
   buttonsSynced?: ConfigChatButtonType[];
+  deeplinks?: { name: string }[];
+  user_vars?: { username: string; vars: Record<string, string> }[];
   http_token?: string;
   tools?: (string | ToolBotType)[];
   evaluators?: ChatEvaluatorType[];

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -304,3 +304,25 @@ describe("handleAddChat", () => {
     expect(ctx.reply).toHaveBeenCalledWith("Chat added: t");
   });
 });
+
+describe("handleStart", () => {
+  it("stores vars from deeplink", async () => {
+    const ctx = { chat: { id: 1 } } as unknown as Context & {
+      startPayload?: string;
+    };
+    const msg = createMsg();
+    msg.text = "/start from:pop";
+    const chat: ConfigChatType = {
+      completionParams: {},
+      chatParams: {},
+      toolParams: {},
+      deeplinks: [{ name: "from" }],
+    } as ConfigChatType;
+    mockGetCtxChatMsg.mockReturnValue({ msg, chat });
+    await commands.handleStart(ctx);
+    expect(chat.user_vars?.[0]).toEqual({
+      username: "user",
+      vars: { from: "pop" },
+    });
+  });
+});

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -307,11 +307,13 @@ describe("handleAddChat", () => {
 
 describe("handleStart", () => {
   it("stores vars from deeplink", async () => {
-    const ctx = { chat: { id: 1 } } as unknown as Context & {
+    const ctx = {
+      chat: { id: 1 },
+      startPayload: Buffer.from("from:pop").toString("base64"),
+    } as unknown as Context & {
       startPayload?: string;
     };
     const msg = createMsg();
-    msg.text = "/start from:pop";
     const chat: ConfigChatType = {
       completionParams: {},
       chatParams: {},

--- a/tests/helpers/llm.extras.test.ts
+++ b/tests/helpers/llm.extras.test.ts
@@ -416,6 +416,7 @@ describe("requestGptAnswer", () => {
   jest.unstable_mockModule("../../src/helpers/placeholders.ts", () => ({
     replaceUrlPlaceholders: (...args: unknown[]) => mockReplaceUrl(...args),
     replaceToolPlaceholders: (...args: unknown[]) => mockReplaceTool(...args),
+    replaceVarsPlaceholders: (s: string, v: Record<string, string>) => s,
   }));
   jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
     getTelegramForwardedUser: (...args: unknown[]) => mockForward(...args),

--- a/tests/helpers/llm.workflow.test.ts
+++ b/tests/helpers/llm.workflow.test.ts
@@ -50,6 +50,7 @@ jest.unstable_mockModule("../../src/helpers/gpt/messages.ts", () => ({
 jest.unstable_mockModule("../../src/helpers/placeholders.ts", () => ({
   replaceUrlPlaceholders: (...args: unknown[]) => mockReplaceUrl(...args),
   replaceToolPlaceholders: (...args: unknown[]) => mockReplaceTool(...args),
+  replaceVarsPlaceholders: (s: string, v: Record<string, string>) => s,
 }));
 
 jest.unstable_mockModule("../../src/helpers/useApi.ts", () => ({

--- a/tests/helpers/replaceVarsPlaceholders.test.ts
+++ b/tests/helpers/replaceVarsPlaceholders.test.ts
@@ -1,0 +1,15 @@
+import { replaceVarsPlaceholders } from "../../src/helpers/placeholders";
+
+describe("replaceVarsPlaceholders", () => {
+  it("replaces vars and blocks", () => {
+    const text = "Hello\n\n<vars:from>Ref: {vars:from}</vars:from>";
+    const res = replaceVarsPlaceholders(text, { from: "pop" });
+    expect(res).toBe("Hello\n\nRef: pop");
+  });
+
+  it("removes block when var missing", () => {
+    const text = "Hello\n\n<vars:from>Ref: {vars:from}</vars:from>";
+    const res = replaceVarsPlaceholders(text, {});
+    expect(res).toBe("Hello\n\n");
+  });
+});


### PR DESCRIPTION
## Summary
- add `deeplinks` and `user_vars` config fields
- store variables from /start deeplink
- expand placeholders helper with `replaceVarsPlaceholders`
- apply vars when building system messages
- cover new logic with tests

## Testing
- `npm run format`
- `npm run typecheck`
- `npm test`
- `npm run coverage-info`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_6888b4503768832cbd423f6ac453cc53