### PR TITLE
Fix lint issues in llm tests

### DIFF
--- a/tests/helpers/llm.extras.test.ts
+++ b/tests/helpers/llm.extras.test.ts
@@ -416,7 +416,7 @@ describe("requestGptAnswer", () => {
   jest.unstable_mockModule("../../src/helpers/placeholders.ts", () => ({
     replaceUrlPlaceholders: (...args: unknown[]) => mockReplaceUrl(...args),
     replaceToolPlaceholders: (...args: unknown[]) => mockReplaceTool(...args),
-    replaceVarsPlaceholders: (s: string, v: Record<string, string>) => s,
+    replaceVarsPlaceholders: (s: string) => s,
   }));
   jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
     getTelegramForwardedUser: (...args: unknown[]) => mockForward(...args),

--- a/tests/helpers/llm.workflow.test.ts
+++ b/tests/helpers/llm.workflow.test.ts
@@ -50,7 +50,7 @@ jest.unstable_mockModule("../../src/helpers/gpt/messages.ts", () => ({
 jest.unstable_mockModule("../../src/helpers/placeholders.ts", () => ({
   replaceUrlPlaceholders: (...args: unknown[]) => mockReplaceUrl(...args),
   replaceToolPlaceholders: (...args: unknown[]) => mockReplaceTool(...args),
-  replaceVarsPlaceholders: (s: string, v: Record<string, string>) => s,
+  replaceVarsPlaceholders: (s: string) => s,
 }));
 
 jest.unstable_mockModule("../../src/helpers/useApi.ts", () => ({


### PR DESCRIPTION
## Summary
- remove unused parameters from unstable mock modules in llm tests

## Testing
- `npm run lint src tests`
- `npm test`
- `npm run test-full`
- `npm run coverage-info`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68890375e1c0832cbf8cf52217823df8