### PR TITLE
Speed up typecheck with incremental tsc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ config-*
 
 .history/
 coverage/
+tsconfig.tsbuildinfo

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ config-*
 
 .history/
 coverage/
-tsconfig.tsbuildinfo

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "incremental": true,
+    "tsBuildInfoFile": "node_modules/.cache/tsconfig.tsbuildinfo",
     "noEmit": true,
     "isolatedModules": true,
     "typeRoots": ["node_modules/@types", "src/@types"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "moduleResolution": "node",
     "allowImportingTsExtensions": true,
     "esModuleInterop": true,
+    "skipLibCheck": true,
+    "incremental": true,
     "noEmit": true,
     "isolatedModules": true,
     "typeRoots": ["node_modules/@types", "src/@types"]


### PR DESCRIPTION
## Summary
- enable `skipLibCheck` and `incremental` in tsconfig
- ignore tsc build cache file

## Testing
- `npm run format`
- `npm run test-full`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68891c5cdc48832cb9417c9767c5e1fd