### PR TITLE
Fix vision messages for responses API

### DIFF
--- a/tests/handlers/onPhotoMain.test.ts
+++ b/tests/handlers/onPhotoMain.test.ts
@@ -70,7 +70,9 @@ describe("onPhoto main flow", () => {
     expect(mockRecognizeImageText).toHaveBeenCalledWith(msg, chat);
     expect(mockOnTextMessage).toHaveBeenCalled();
     const calledCtx = mockOnTextMessage.mock.calls[0][0];
-    expect(calledCtx.message.text).toBe("cap\nocr");
+    expect(calledCtx.message.text).toBe(
+      "cap\n<image-recognized-text>ocr</image-recognized-text>",
+    );
     expect(mockSendTelegramMessage).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- support vision content conversion in responses API
- test responses API with vision messages
- update expected text in onPhoto test

## Testing
- `npm run test-full`
- `npm run coverage-info`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688b80fd1e10832c84c160b042dd7832