### PR TITLE
Fix Docker SQLite build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: application build
-FROM node:20-alpine AS builder
+FROM node:20-bookworm-slim AS builder
 
 # install dependencies and build
 WORKDIR /build
@@ -7,11 +7,13 @@ COPY package*.json ./
 RUN npm install
 
 # Stage 2: runtime image with uvx
-FROM node:20-alpine
+FROM node:20-bookworm-slim
 
 # install ssh, Python and pip, then uv (includes uvx)
-RUN apk update \
-   && apk add --no-cache openssh ffmpeg
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      openssh-client ffmpeg wget \
+    && rm -rf /var/lib/apt/lists/*
 #   python3 py3-pip \
 #    && python3 -m pip install --upgrade pip \
 #    && pip install uv


### PR DESCRIPTION
## Summary
- switch Docker base to `node:20-bookworm-slim`
- install runtime packages via `apt-get`

This avoids `fcntl64` symbol errors from `better-sqlite3` on alpine.

## Testing
- `npm run format`
- `npm run typecheck`
- `npm run test-full`

------
https://chatgpt.com/codex/tasks/task_e_688ca5f0ad0c832c8c1ce8cb95ef3fa2