### PR TITLE
feat: per-chat vector memory paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,13 +436,13 @@ Other useful chat parameters include:
 
 ## Vector memory
 
-Enable semantic memory with `chatParams.vectorMemory`. Messages starting with `запомни` are embedded and stored in a SQLite database using `sqlite-vec`. Use the `search_memory` tool to find related snippets. Set `toolParams.vectorMemory.alwaysSearch` to automatically search memory before answering.
+Enable semantic memory with `chatParams.vector_memory`. Messages starting with `запомни` are embedded and stored in a SQLite database using `sqlite-vec`. Use the `search_memory` tool to find related snippets. Set `toolParams.vector_memory.alwaysSearch` to automatically search memory before answering.
 
 ```yaml
 chatParams:
-  vectorMemory: true
+  vector_memory: true
 toolParams:
-  vectorMemory:
+  vector_memory:
     dbPath: data/memory/default.sqlite
     dimension: 1536
     alwaysSearch: false

--- a/README.md
+++ b/README.md
@@ -170,18 +170,18 @@ import { OpenAI } from "openai";
 const client = new OpenAI();
 
 const stream = await client.responses.create({
-    model: "gpt-4.1",
-    input: [
-        {
-            role: "user",
-            content: "Say 'double bubble bath' ten times fast.",
-        },
-    ],
-    stream: true,
+  model: "gpt-4.1",
+  input: [
+    {
+      role: "user",
+      content: "Say 'double bubble bath' ten times fast.",
+    },
+  ],
+  stream: true,
 });
 
 for await (const event of stream) {
-    console.log(event);
+  console.log(event);
 }
 ```
 
@@ -190,7 +190,7 @@ The Responses API uses semantic events for streaming. Each event is typed with a
 For a full list of event types, see the [API reference for streaming](/docs/api-reference/responses-streaming). Here are a few examples:
 
 ```python
-type StreamingEvent = 
+type StreamingEvent =
 | ResponseCreatedEvent
 | ResponseInProgressEvent
 | ResponseFailedEvent
@@ -236,8 +236,8 @@ For a full list of events you can listen for, see the [API reference for streami
 
 For more advanced use cases, like streaming tool calls, check out the following dedicated guides:
 
-*   [Streaming function calls](/docs/guides/function-calling#streaming)
-*   [Streaming structured output](/docs/guides/structured-outputs#streaming)
+- [Streaming function calls](/docs/guides/function-calling#streaming)
+- [Streaming structured output](/docs/guides/structured-outputs#streaming)
 
 ### Moderation risk
 
@@ -443,10 +443,16 @@ chatParams:
   vectorMemory: true
 toolParams:
   vectorMemory:
-    dbPath: data/memory.sqlite
+    dbPath: data/memory/default.sqlite
     dimension: 1536
     alwaysSearch: false
 ```
+
+By default, databases are stored under `data/memory/`:
+
+- private chats: `data/memory/private/{username}.sqlite`
+- chats for specific bots: `data/memory/bots/{bot_name}.sqlite`
+- group chats: `data/memory/groups/{chat_name_or_id_safe}.sqlite`
 
 - The available tool names are fetched from the MCP servers listed in `config.mcpServers`.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -135,14 +135,14 @@ export function generateConfig(): ConfigType {
           showToolMessages: true,
           useResponsesApi: false,
           streaming: false,
-          vectorMemory: false,
+          vector_memory: false,
         },
         toolParams: {
           brainstorm: {
             promptBefore: "Составь только краткий план действий.",
             promptAfter: "Выше написан краткий план действий. Полный ответ:",
           },
-          vectorMemory: {
+          vector_memory: {
             dbPath: "data/memory/default.sqlite",
             dimension: 1536,
             alwaysSearch: false,
@@ -192,14 +192,14 @@ export function generateConfig(): ConfigType {
           showToolMessages: true,
           useResponsesApi: false,
           streaming: false,
-          vectorMemory: false,
+          vector_memory: false,
         },
         toolParams: {
           brainstorm: {
             promptBefore: "Составь только краткий план действий.",
             promptAfter: "Выше написан краткий план действий. Полный ответ:",
           },
-          vectorMemory: {
+          vector_memory: {
             dbPath: "data/memory/default.sqlite",
             dimension: 1536,
             alwaysSearch: false,
@@ -230,6 +230,27 @@ export function generatePrivateChatConfig(username: string) {
     toolParams: {} as ToolParamsType,
     chatParams: {} as ChatParamsType,
   } as ConfigChatType;
+}
+
+export function updateChatInConfig(chatConfig: ConfigChatType) {
+  const config = readConfig();
+  let idx = -1;
+  if (chatConfig.id) {
+    idx = config.chats.findIndex(
+      (c) => c.id === chatConfig.id || c.ids?.includes(chatConfig.id!),
+    );
+  }
+  if (idx === -1 && chatConfig.username) {
+    idx = config.chats.findIndex((c) => c.username === chatConfig.username);
+  }
+  if (idx === -1) {
+    idx = config.chats.findIndex((c) => c.name === chatConfig.name);
+  }
+  if (idx === -1) {
+    throw new Error("Chat not found in config");
+  }
+  config.chats[idx] = chatConfig;
+  writeConfig(configPath, config);
 }
 
 export function checkConfigSchema(config: ConfigType) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -143,7 +143,7 @@ export function generateConfig(): ConfigType {
             promptAfter: "Выше написан краткий план действий. Полный ответ:",
           },
           vectorMemory: {
-            dbPath: "data/memory.sqlite",
+            dbPath: "data/memory/default.sqlite",
             dimension: 1536,
             alwaysSearch: false,
           },
@@ -200,7 +200,7 @@ export function generateConfig(): ConfigType {
             promptAfter: "Выше написан краткий план действий. Полный ответ:",
           },
           vectorMemory: {
-            dbPath: "data/memory.sqlite",
+            dbPath: "data/memory/default.sqlite",
             dimension: 1536,
             alwaysSearch: false,
           },

--- a/src/handlers/onTextMessage.ts
+++ b/src/handlers/onTextMessage.ts
@@ -67,7 +67,7 @@ export default async function onTextMessage(
   if (buttonResponse) return buttonResponse;
 
   if (
-    chat.chatParams?.vectorMemory &&
+    chat.chatParams?.vector_memory &&
     msg.text?.toLowerCase().startsWith("запомни")
   ) {
     const text = msg.text.replace(/^запомни\s*/i, "");

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -67,6 +67,14 @@ export function ensureDirectoryExists(filePath: string) {
   }
 }
 
+export function safeFilename(filename: string, def: string): string {
+  const safe = filename
+    .toLowerCase()
+    .replace(/[^a-z0-9а-яё]+/g, "_")
+    .replace(/^_|_$/g, "");
+  return safe || def;
+}
+
 export function sendToHttp(res: express.Response | undefined, text: string) {
   if (!res) return;
   res.write(text + "\n");

--- a/src/tools/search_memory.ts
+++ b/src/tools/search_memory.ts
@@ -9,10 +9,10 @@ import { searchEmbedding } from "../helpers/embeddings.ts";
 import type { Message } from "telegraf/types";
 
 export const description = "Search stored chat memory";
-export const details = `- searches vector memory for similar snippets\n- dbPath: toolParams.vectorMemory.dbPath`;
+export const details = `- searches vector memory for similar snippets\n- dbPath: toolParams.vector_memory.dbPath`;
 
 export const defaultParams = {
-  vectorMemory: {
+  vector_memory: {
     dbPath: "data/memory/default.sqlite",
     dimension: 1536,
   },
@@ -55,7 +55,7 @@ export class SearchMemoryClient extends AIFunctionsProvider {
   }
 
   async prompt_append(): Promise<string | undefined> {
-    if (!this.configChat.toolParams?.vectorMemory?.alwaysSearch) return;
+    if (!this.configChat.toolParams?.vector_memory?.alwaysSearch) return;
     const last = this.thread.msgs[this.thread.msgs.length - 1] as
       | Message.TextMessage
       | undefined;

--- a/src/tools/search_memory.ts
+++ b/src/tools/search_memory.ts
@@ -13,7 +13,7 @@ export const details = `- searches vector memory for similar snippets\n- dbPath:
 
 export const defaultParams = {
   vectorMemory: {
-    dbPath: "data/memory.sqlite",
+    dbPath: "data/memory/default.sqlite",
     dimension: 1536,
   },
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,7 @@ export type ChatParamsType = {
   placeholderCacheTime?: number;
   useResponsesApi?: boolean;
   streaming?: boolean;
-  vectorMemory?: boolean;
+  vector_memory?: boolean;
 };
 
 export type CompletionParamsType = {
@@ -184,6 +184,12 @@ export type BrainstormParamsType = {
   promptAfter?: string;
 };
 
+export type VectorMemoryParamsType = {
+  dbPath: string;
+  dimension: number;
+  alwaysSearch?: boolean;
+};
+
 export type GptContextType = {
   thread: ThreadStateType;
   messages: OpenAI.ChatCompletionMessageParam[];
@@ -208,11 +214,7 @@ export type ToolParamsType = {
     textCol: string;
     cacheTime: number;
   };
-  vectorMemory?: {
-    dbPath: string;
-    dimension: number;
-    alwaysSearch?: boolean;
-  };
+  vector_memory?: VectorMemoryParamsType;
 };
 
 // MCP tool configuration

--- a/tests/agent-runner.test.ts
+++ b/tests/agent-runner.test.ts
@@ -13,6 +13,7 @@ afterEach(() => {
 
 jest.unstable_mockModule("../src/config.ts", () => ({
   readConfig: () => mockReadConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../src/helpers/gpt/llm.ts", () => ({

--- a/tests/agent-runner.test.ts
+++ b/tests/agent-runner.test.ts
@@ -28,6 +28,7 @@ jest.unstable_mockModule("../src/helpers/history.ts", () => ({
 jest.unstable_mockModule("../src/helpers.ts", () => ({
   log: (...args: unknown[]) => mockLog(...args),
   agentNameToId: (...args: unknown[]) => mockAgentNameToId(...args),
+  safeFilename: jest.fn(),
 }));
 
 let runAgent: typeof import("../src/agent-runner.ts").runAgent;

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -15,6 +15,7 @@ const mockUseConfig = jest.fn();
 
 jest.unstable_mockModule("../src/config.ts", () => ({
   useConfig: () => mockUseConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("telegraf", () => ({

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -52,6 +52,7 @@ jest.unstable_mockModule("../src/config.ts", () => ({
   writeConfig: (...args: unknown[]) => mockWriteConfig(...args),
   generatePrivateChatConfig: (u: string) => mockGeneratePrivateChatConfig(u),
   readConfig: () => mockReadConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../src/telegram/context.ts", () => ({

--- a/tests/configExtras.test.ts
+++ b/tests/configExtras.test.ts
@@ -13,6 +13,7 @@ const mockDump = jest.fn((obj) => JSON.stringify(obj));
 
 jest.unstable_mockModule("../src/helpers.ts", () => ({
   log: mockLog,
+  safeFilename: jest.fn(),
 }));
 
 jest.unstable_mockModule("lodash.debounce", () => ({

--- a/tests/connectMcp.test.ts
+++ b/tests/connectMcp.test.ts
@@ -40,6 +40,7 @@ jest.unstable_mockModule(
 jest.unstable_mockModule("../src/helpers.ts", () => ({
   __esModule: true,
   log: (...args: unknown[]) => mockLog(...args),
+  safeFilename: jest.fn(),
 }));
 
 let connectMcp: typeof import("../src/mcp.ts").connectMcp;

--- a/tests/handlers/isMentioned.test.ts
+++ b/tests/handlers/isMentioned.test.ts
@@ -6,6 +6,7 @@ const mockUseConfig = jest.fn();
 
 jest.unstable_mockModule("../../src/config.ts", () => ({
   useConfig: () => mockUseConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 const { isMentioned } = await import("../../src/handlers/access.ts");

--- a/tests/handlers/onAudioMain.test.ts
+++ b/tests/handlers/onAudioMain.test.ts
@@ -26,6 +26,7 @@ jest.unstable_mockModule("../../src/config.ts", () => ({
   checkConfigSchema: jest.fn(),
   logConfigChanges: jest.fn(),
   setConfigPath: jest.fn(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../../src/telegram/send.ts", () => ({

--- a/tests/handlers/onAudioMain.test.ts
+++ b/tests/handlers/onAudioMain.test.ts
@@ -69,7 +69,9 @@ beforeEach(async () => {
     arrayBuffer: async () => Buffer.from("data"),
   }) as unknown as typeof fetch;
   jest.spyOn(fs.promises, "writeFile").mockResolvedValue();
-  jest.spyOn(fs, "existsSync").mockReturnValue(true);
+  jest
+    .spyOn(fs, "existsSync")
+    .mockImplementation((p) => !String(p).startsWith("data"));
   jest.spyOn(fs, "unlinkSync").mockImplementation(() => {});
   mockConvertToMp3.mockResolvedValue("file.mp3");
   mockSendAudioWhisper.mockResolvedValue({ text: "hello" });

--- a/tests/handlers/onPhotoMain.test.ts
+++ b/tests/handlers/onPhotoMain.test.ts
@@ -19,6 +19,7 @@ jest.unstable_mockModule("../../src/helpers/vision.ts", () => ({
 
 jest.unstable_mockModule("../../src/config.ts", () => ({
   useConfig: () => mockUseConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../../src/telegram/send.ts", () => ({

--- a/tests/handlers/onTextMessageAnswer.test.ts
+++ b/tests/handlers/onTextMessageAnswer.test.ts
@@ -46,6 +46,7 @@ jest.unstable_mockModule("../../src/helpers/google.ts", () => ({
 jest.unstable_mockModule("../../src/config.ts", () => ({
   useConfig: () => mockUseConfig(),
   syncButtons: mockSyncButtons,
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../../src/helpers/gpt.ts", () => ({

--- a/tests/handlers/onTextMessageCancel.test.ts
+++ b/tests/handlers/onTextMessageCancel.test.ts
@@ -147,6 +147,7 @@ jest.unstable_mockModule("../../src/config.ts", () => ({
   checkConfigSchema: jest.fn(),
   logConfigChanges: jest.fn(),
   setConfigPath: jest.fn(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../../src/threads.ts", () => ({

--- a/tests/handlers/photoAudioEarly.test.ts
+++ b/tests/handlers/photoAudioEarly.test.ts
@@ -24,6 +24,7 @@ jest.unstable_mockModule("../../src/config.ts", () => ({
   useConfig: () => mockUseConfig(),
   readConfig: jest.fn(),
   syncButtons: jest.fn(),
+  updateChatInConfig: jest.fn(),
 }));
 
 const { default: onPhoto } = await import("../../src/handlers/onPhoto.ts");

--- a/tests/healthHandler.test.ts
+++ b/tests/healthHandler.test.ts
@@ -8,6 +8,7 @@ const mockIsMqttConnected = jest.fn();
 jest.unstable_mockModule("../src/config.ts", () => ({
   __esModule: true,
   useConfig: () => mockUseConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../src/bot", () => ({

--- a/tests/helpers/gptTools.test.ts
+++ b/tests/helpers/gptTools.test.ts
@@ -36,6 +36,7 @@ jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
 
 jest.unstable_mockModule("../../src/config.ts", () => ({
   useConfig: () => mockUseConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../../src/threads.ts", () => ({

--- a/tests/helpers/llm.workflow.test.ts
+++ b/tests/helpers/llm.workflow.test.ts
@@ -67,6 +67,7 @@ jest.unstable_mockModule("langfuse", () => ({
 
 jest.unstable_mockModule("../../src/config.ts", () => ({
   useConfig: () => mockUseConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../../src/threads.ts", () => ({

--- a/tests/helpers/stt.test.ts
+++ b/tests/helpers/stt.test.ts
@@ -38,6 +38,7 @@ const mockUseConfig = jest.fn(() => ({
 
 jest.unstable_mockModule("../../src/config.ts", () => ({
   useConfig: () => mockUseConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 let stt: typeof import("../../src/helpers/stt.ts");

--- a/tests/helpers/useApi.test.ts
+++ b/tests/helpers/useApi.test.ts
@@ -10,6 +10,7 @@ const mockOpenAI = jest.fn(function (
 
 jest.unstable_mockModule("../../src/config.ts", () => ({
   useConfig: () => mockUseConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("openai", () => ({

--- a/tests/helpers/useLangfuse.test.ts
+++ b/tests/helpers/useLangfuse.test.ts
@@ -17,6 +17,7 @@ const mockUseConfig = jest.fn();
 
 jest.unstable_mockModule("../../src/config.ts", () => ({
   useConfig: () => mockUseConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("langfuse", () => ({

--- a/tests/helpers/useTools.test.ts
+++ b/tests/helpers/useTools.test.ts
@@ -28,6 +28,7 @@ jest.unstable_mockModule("../../src/helpers.ts", () => ({
 
 jest.unstable_mockModule("../../src/config.ts", () => ({
   readConfig: () => mockReadConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../../src/mcp.ts", () => ({

--- a/tests/helpers/vision.test.ts
+++ b/tests/helpers/vision.test.ts
@@ -19,6 +19,7 @@ jest.unstable_mockModule("../../src/helpers/gpt.ts", () => ({
 
 jest.unstable_mockModule("../../src/config.ts", () => ({
   useConfig: () => mockUseConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 let vision: typeof import("../../src/helpers/vision.ts");

--- a/tests/httpHandlersAgent.test.ts
+++ b/tests/httpHandlersAgent.test.ts
@@ -35,6 +35,7 @@ jest.unstable_mockModule("../src/helpers.ts", () => ({
   log: (...args: unknown[]) => mockLog(...args),
   agentNameToId: (name: string) => name.length,
   sendToHttp: jest.fn(),
+  safeFilename: jest.fn(),
 }));
 
 let agentPostHandler: typeof import("../src/httpHandlers.ts").agentPostHandler;

--- a/tests/httpHandlersAgent.test.ts
+++ b/tests/httpHandlersAgent.test.ts
@@ -17,6 +17,7 @@ jest.unstable_mockModule("../src/config.ts", () => ({
   __esModule: true,
   useConfig: () => mockUseConfig(),
   readConfig: () => ({}),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../src/helpers/gpt/llm.ts", () => ({

--- a/tests/index.http.test.ts
+++ b/tests/index.http.test.ts
@@ -31,6 +31,8 @@ jest.unstable_mockModule("../src/helpers.ts", () => ({
   log: (...args: unknown[]) => mockLog(...args),
   agentNameToId: jest.fn(),
   sendToHttp: jest.fn(),
+  ensureDirectoryExists: jest.fn(),
+  safeFilename: jest.fn(),
 }));
 
 jest.unstable_mockModule("express", () => ({

--- a/tests/index.http.test.ts
+++ b/tests/index.http.test.ts
@@ -24,6 +24,7 @@ jest.unstable_mockModule("../src/config.ts", () => ({
   readConfig: jest.fn(),
   generatePrivateChatConfig: jest.fn(),
   syncButtons: jest.fn(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../src/helpers.ts", () => ({

--- a/tests/index.start.test.ts
+++ b/tests/index.start.test.ts
@@ -27,6 +27,7 @@ jest.unstable_mockModule("../src/config.ts", () => ({
   readConfig: jest.fn(),
   generatePrivateChatConfig: jest.fn(),
   syncButtons: jest.fn(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../src/mqtt.ts", () => ({

--- a/tests/index.start.test.ts
+++ b/tests/index.start.test.ts
@@ -70,6 +70,8 @@ jest.unstable_mockModule("../src/helpers.ts", () => ({
   log: (...args: unknown[]) => mockLog(...args),
   agentNameToId: jest.fn(),
   sendToHttp: jest.fn(),
+  ensureDirectoryExists: jest.fn(),
+  safeFilename: jest.fn(),
 }));
 
 jest.unstable_mockModule("express", () => ({

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -39,6 +39,7 @@ jest.unstable_mockModule("../src/config.ts", () => ({
   writeConfig: (...args: unknown[]) => mockWriteConfig(...args),
   watchConfigChanges: (...args: unknown[]) => mockWatchConfigChanges(...args),
   readConfig: jest.fn(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../src/bot", () => ({

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -58,6 +58,7 @@ jest.unstable_mockModule("../src/helpers.ts", () => ({
   log: (...args: unknown[]) => mockLog(...args),
   agentNameToId: jest.fn(),
   sendToHttp: jest.fn(),
+  safeFilename: jest.fn(),
 }));
 
 jest.unstable_mockModule("../src/mqtt.ts", () => ({

--- a/tests/mcp.connect.test.ts
+++ b/tests/mcp.connect.test.ts
@@ -46,6 +46,7 @@ jest.unstable_mockModule("@modelcontextprotocol/sdk/types.js", () => ({
 
 jest.unstable_mockModule("../src/helpers.ts", () => ({
   log: (...args: unknown[]) => mockLog(...args),
+  safeFilename: jest.fn(),
 }));
 
 let connectMcp: typeof import("../src/mcp.ts").connectMcp;

--- a/tests/mqtt.test.ts
+++ b/tests/mqtt.test.ts
@@ -20,6 +20,7 @@ jest.unstable_mockModule("mqtt", () => ({
 
 jest.unstable_mockModule("../src/config.ts", () => ({
   useConfig: () => mockUseConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../src/agent-runner.ts", () => ({

--- a/tests/mqtt.test.ts
+++ b/tests/mqtt.test.ts
@@ -28,6 +28,7 @@ jest.unstable_mockModule("../src/agent-runner.ts", () => ({
 
 jest.unstable_mockModule("../src/helpers.ts", () => ({
   log: (...args: unknown[]) => mockLog(...args),
+  safeFilename: jest.fn(),
 }));
 
 let useMqtt: typeof import("../src/mqtt.ts").useMqtt;

--- a/tests/runAgent.test.ts
+++ b/tests/runAgent.test.ts
@@ -10,6 +10,7 @@ jest.unstable_mockModule("../src/helpers/gpt/llm.ts", () => ({
 jest.unstable_mockModule("../src/config.ts", () => ({
   readConfig: mockReadConfig,
   useConfig: () => mockReadConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 import type { runAgent } from "../src/agent-runner.ts";

--- a/tests/telegram/context.test.ts
+++ b/tests/telegram/context.test.ts
@@ -9,6 +9,7 @@ const mockLog = jest.fn();
 
 jest.unstable_mockModule("../../src/config.ts", () => ({
   useConfig: () => mockUseConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../../src/helpers.ts", () => ({

--- a/tests/telegram/send.test.ts
+++ b/tests/telegram/send.test.ts
@@ -6,6 +6,7 @@ const mockUseConfig = jest.fn();
 
 jest.unstable_mockModule("../../src/config.ts", () => ({
   useConfig: () => mockUseConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 const { isAdminUser, buildButtonRows, getFullName, getTelegramForwardedUser } =

--- a/tests/toolEndpoint.test.ts
+++ b/tests/toolEndpoint.test.ts
@@ -10,6 +10,7 @@ const mockLog = jest.fn();
 // Mock the modules
 jest.unstable_mockModule("../src/config.ts", () => ({
   useConfig: () => mockUseConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../src/helpers/gpt/tools.ts", () => ({

--- a/tests/toolEndpoint.test.ts
+++ b/tests/toolEndpoint.test.ts
@@ -34,6 +34,7 @@ jest.unstable_mockModule("../src/helpers.ts", () => ({
     }
     return Math.abs(hash);
   },
+  safeFilename: jest.fn(),
 }));
 
 // Import the function to test after setting up mocks

--- a/tests/tools/brainstorm.test.ts
+++ b/tests/tools/brainstorm.test.ts
@@ -13,6 +13,7 @@ jest.unstable_mockModule("../../src/helpers/gpt.ts", () => ({
 
 jest.unstable_mockModule("../../src/config.ts", () => ({
   readConfig: () => mockReadConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 let mod: typeof import("../../src/tools/brainstorm.ts");

--- a/tests/tools/change_access_settings.test.ts
+++ b/tests/tools/change_access_settings.test.ts
@@ -8,6 +8,7 @@ jest.unstable_mockModule("../../src/config.ts", () => ({
   __esModule: true,
   readConfig: () => mockReadConfig(),
   writeConfig: (...args: unknown[]) => mockWriteConfig(...args),
+  updateChatInConfig: jest.fn(),
 }));
 
 let mod: typeof import("../../src/tools/change_access_settings.ts");

--- a/tests/tools/change_chat_settings.test.ts
+++ b/tests/tools/change_chat_settings.test.ts
@@ -15,6 +15,7 @@ jest.unstable_mockModule("../../src/config.ts", () => ({
   writeConfig: (...args: unknown[]) => mockWriteConfig(...args),
   generatePrivateChatConfig: (...args: unknown[]) =>
     mockGeneratePrivateChatConfig(...args),
+  updateChatInConfig: jest.fn(),
 }));
 
 let ChangeChatSettingsClient: typeof import("../../src/tools/change_chat_settings.ts").ChangeChatSettingsClient;

--- a/tests/tools/create_agent.test.ts
+++ b/tests/tools/create_agent.test.ts
@@ -12,6 +12,7 @@ jest.unstable_mockModule("../../src/config.ts", () => ({
   __esModule: true,
   readConfig: () => mockReadConfig(),
   writeConfig: (...args: unknown[]) => mockWriteConfig(...args),
+  updateChatInConfig: jest.fn(),
 }));
 
 let CreateAgentClient: typeof import("../../src/tools/create_agent.ts").CreateAgentClient;

--- a/tests/tools/get_next_offday.test.ts
+++ b/tests/tools/get_next_offday.test.ts
@@ -5,6 +5,7 @@ const mockReadConfig = jest.fn();
 
 jest.unstable_mockModule("../../src/config.ts", () => ({
   readConfig: () => mockReadConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 let mod: typeof import("../../src/tools/get_next_offday.ts");

--- a/tests/tools/read_google_sheet.test.ts
+++ b/tests/tools/read_google_sheet.test.ts
@@ -11,6 +11,7 @@ const mockReadSheet = jest.fn();
 
 jest.unstable_mockModule("../../src/config.ts", () => ({
   readConfig: () => mockReadConfig(),
+  updateChatInConfig: jest.fn(),
 }));
 
 jest.unstable_mockModule("../../src/helpers/readGoogleSheet.ts", () => ({

--- a/tests/tools/read_knowledge_json.test.ts
+++ b/tests/tools/read_knowledge_json.test.ts
@@ -6,6 +6,7 @@ import type { ConfigChatType } from "../../src/types";
 
 jest.unstable_mockModule("../../src/config.ts", () => ({
   readConfig: () => ({ auth: {}, chats: [] }),
+  updateChatInConfig: jest.fn(),
 }));
 
 let mod: typeof import("../../src/tools/read_knowledge_json.ts");

--- a/tests/tools/search_memory.test.ts
+++ b/tests/tools/search_memory.test.ts
@@ -20,8 +20,8 @@ function cfg(dbPath: string): ConfigChatType {
     name: "c",
     agent_name: "a",
     completionParams: {},
-    chatParams: { vectorMemory: true },
-    toolParams: { vectorMemory: { dbPath, dimension: 3 } },
+    chatParams: { vector_memory: true },
+    toolParams: { vector_memory: { dbPath, dimension: 3 } },
   } as ConfigChatType;
 }
 

--- a/tests/vectorMemory.test.ts
+++ b/tests/vectorMemory.test.ts
@@ -1,0 +1,87 @@
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import type { ConfigChatType } from "../src/types";
+
+jest.unstable_mockModule("../src/helpers/useApi.ts", () => ({
+  useApi: () => ({
+    embeddings: {
+      create: async () => ({ data: [{ embedding: [0.1, 0.2, 0.3] }] }),
+    },
+  }),
+}));
+
+let embeddings: typeof import("../src/helpers/embeddings.ts");
+
+function baseChat(): ConfigChatType {
+  return {
+    id: 1,
+    name: "test",
+    completionParams: {},
+    chatParams: { vectorMemory: true },
+    toolParams: { vectorMemory: { dimension: 3 } },
+  } as ConfigChatType;
+}
+
+beforeEach(async () => {
+  jest.resetModules();
+  embeddings = await import("../src/helpers/embeddings.ts");
+});
+
+afterEach(() => {
+  fs.rmSync("data", { recursive: true, force: true });
+});
+
+describe("defaultMemoryDbPath", () => {
+  it("uses username for private chats", async () => {
+    const chat = { ...baseChat(), username: "alice" } as ConfigChatType;
+    await embeddings.saveEmbedding({ text: "hello", metadata: {}, chat });
+    const expected = path.join("data", "memory", "private", "alice.sqlite");
+    expect(fs.existsSync(expected)).toBe(true);
+    expect(chat.toolParams?.vectorMemory?.dbPath).toBe(expected);
+    embeddings.closeDb(expected);
+  });
+
+  it("uses bot_name for bot chats", async () => {
+    const chat = { ...baseChat(), bot_name: "mybot" } as ConfigChatType;
+    await embeddings.saveEmbedding({ text: "hello", metadata: {}, chat });
+    const expected = path.join("data", "memory", "bots", "mybot.sqlite");
+    expect(fs.existsSync(expected)).toBe(true);
+    expect(chat.toolParams?.vectorMemory?.dbPath).toBe(expected);
+    embeddings.closeDb(expected);
+  });
+
+  it("uses sanitized group name for group chats", async () => {
+    const chat = { ...baseChat(), name: "My Group!", id: 42 } as ConfigChatType;
+    await embeddings.saveEmbedding({ text: "hello", metadata: {}, chat });
+    const expected = path.join("data", "memory", "groups", "my_group.sqlite");
+    expect(fs.existsSync(expected)).toBe(true);
+    expect(chat.toolParams?.vectorMemory?.dbPath).toBe(expected);
+    embeddings.closeDb(expected);
+  });
+
+  it("allows Cyrillic characters in group name", async () => {
+    const chat = { ...baseChat(), name: "Группа", id: 123 } as ConfigChatType;
+    await embeddings.saveEmbedding({ text: "hello", metadata: {}, chat });
+    const expected = path.join("data", "memory", "groups", "группа.sqlite");
+    expect(fs.existsSync(expected)).toBe(true);
+    expect(chat.toolParams?.vectorMemory?.dbPath).toBe(expected);
+    embeddings.closeDb(expected);
+  });
+
+  it("falls back to chat id when name sanitizes empty", async () => {
+    const chat = { ...baseChat(), name: "!!!", id: 456 } as ConfigChatType;
+    await embeddings.saveEmbedding({ text: "hello", metadata: {}, chat });
+    const expected = path.join("data", "memory", "groups", "456.sqlite");
+    expect(fs.existsSync(expected)).toBe(true);
+    expect(chat.toolParams?.vectorMemory?.dbPath).toBe(expected);
+    embeddings.closeDb(expected);
+  });
+});

--- a/tests/vector_memory.test.ts
+++ b/tests/vector_memory.test.ts
@@ -9,6 +9,7 @@ import {
 import fs from "fs";
 import path from "path";
 import type { ConfigChatType } from "../src/types";
+import { generateConfig, setConfigPath, writeConfig } from "../src/config";
 
 jest.unstable_mockModule("../src/helpers/useApi.ts", () => ({
   useApi: () => ({
@@ -25,63 +26,79 @@ function baseChat(): ConfigChatType {
     id: 1,
     name: "test",
     completionParams: {},
-    chatParams: { vectorMemory: true },
-    toolParams: { vectorMemory: { dimension: 3 } },
+    chatParams: { vector_memory: true },
+    toolParams: { vector_memory: { dimension: 3 } },
   } as ConfigChatType;
+}
+
+function writeChat(chat: ConfigChatType) {
+  const config = generateConfig();
+  config.chats.push(chat);
+  writeConfig("test-config.yml", config);
 }
 
 beforeEach(async () => {
   jest.resetModules();
+  process.env.CONFIG = "test-config.yml";
+  setConfigPath("test-config.yml");
   embeddings = await import("../src/helpers/embeddings.ts");
 });
 
 afterEach(() => {
   fs.rmSync("data", { recursive: true, force: true });
+  fs.rmSync("test-config.yml", { force: true });
+  delete process.env.CONFIG;
+  setConfigPath("config.yml");
 });
 
 describe("defaultMemoryDbPath", () => {
   it("uses username for private chats", async () => {
     const chat = { ...baseChat(), username: "alice" } as ConfigChatType;
+    writeChat(chat);
     await embeddings.saveEmbedding({ text: "hello", metadata: {}, chat });
     const expected = path.join("data", "memory", "private", "alice.sqlite");
     expect(fs.existsSync(expected)).toBe(true);
-    expect(chat.toolParams?.vectorMemory?.dbPath).toBe(expected);
+    expect(chat.toolParams?.vector_memory?.dbPath).toBe(expected);
     embeddings.closeDb(expected);
   });
 
   it("uses bot_name for bot chats", async () => {
     const chat = { ...baseChat(), bot_name: "mybot" } as ConfigChatType;
+    writeChat(chat);
     await embeddings.saveEmbedding({ text: "hello", metadata: {}, chat });
     const expected = path.join("data", "memory", "bots", "mybot.sqlite");
     expect(fs.existsSync(expected)).toBe(true);
-    expect(chat.toolParams?.vectorMemory?.dbPath).toBe(expected);
+    expect(chat.toolParams?.vector_memory?.dbPath).toBe(expected);
     embeddings.closeDb(expected);
   });
 
   it("uses sanitized group name for group chats", async () => {
     const chat = { ...baseChat(), name: "My Group!", id: 42 } as ConfigChatType;
+    writeChat(chat);
     await embeddings.saveEmbedding({ text: "hello", metadata: {}, chat });
     const expected = path.join("data", "memory", "groups", "my_group.sqlite");
     expect(fs.existsSync(expected)).toBe(true);
-    expect(chat.toolParams?.vectorMemory?.dbPath).toBe(expected);
+    expect(chat.toolParams?.vector_memory?.dbPath).toBe(expected);
     embeddings.closeDb(expected);
   });
 
   it("allows Cyrillic characters in group name", async () => {
     const chat = { ...baseChat(), name: "Группа", id: 123 } as ConfigChatType;
+    writeChat(chat);
     await embeddings.saveEmbedding({ text: "hello", metadata: {}, chat });
     const expected = path.join("data", "memory", "groups", "группа.sqlite");
     expect(fs.existsSync(expected)).toBe(true);
-    expect(chat.toolParams?.vectorMemory?.dbPath).toBe(expected);
+    expect(chat.toolParams?.vector_memory?.dbPath).toBe(expected);
     embeddings.closeDb(expected);
   });
 
   it("falls back to chat id when name sanitizes empty", async () => {
     const chat = { ...baseChat(), name: "!!!", id: 456 } as ConfigChatType;
+    writeChat(chat);
     await embeddings.saveEmbedding({ text: "hello", metadata: {}, chat });
     const expected = path.join("data", "memory", "groups", "456.sqlite");
     expect(fs.existsSync(expected)).toBe(true);
-    expect(chat.toolParams?.vectorMemory?.dbPath).toBe(expected);
+    expect(chat.toolParams?.vector_memory?.dbPath).toBe(expected);
     embeddings.closeDb(expected);
   });
 });


### PR DESCRIPTION
## Summary
- add `safeFilename` helper to sanitize names including Cyrillic and fallback to defaults
- persist per-chat vector memory path back into config using `chat.name` or `chat.id`
- document group DB path format and test path resolution for various chat types

## Testing
- `npm run typecheck`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_688dea706be0832c9954e96f2048b692