### PR TITLE
feat: add memory delete tool and rename memory search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ This project is a TypeScript Telegram bot. The codebase uses Node.js tooling wit
 - Add tests for new features.
 - Add documentation for new features.
 - If config type was changed, change config.ts generateConfig function.
+- **Never** change or delete files in `data/` directory in tests.
 
 ## Rules before commit
 - Always run `npm run typecheck` before commit.

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ Other useful chat parameters include:
 
 ## Vector memory
 
-Enable semantic memory with `chatParams.vector_memory`. Messages starting with `запомни` are embedded and stored in a SQLite database using `sqlite-vec`. Use the `memory_search` tool to find related snippets or `memory_delete` to remove them. Set `toolParams.vector_memory.alwaysSearch` to automatically search memory before answering.
+Enable semantic memory with `chatParams.vector_memory`. Messages starting with `запомни` (any punctuation immediately after the keyword is ignored) are embedded and stored in a SQLite database using `sqlite-vec`. Use the `memory_search` tool to find related snippets or `memory_delete` to remove them. Set `toolParams.vector_memory.alwaysSearch` to automatically search memory before answering.
 
 ```yaml
 chatParams:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Telegram bot with functions tools.
 - Automatic history cleanup with `forgetTimeout`
 - Abort previous answer if user sends a new message
 - Optional delay between split messages
-- Vector memory and `search_memory` tool (optional automatic search)
+- Vector memory with `memory_search` and `memory_delete` tools (optional automatic search)
 
 ## Pipeline
 
@@ -48,7 +48,8 @@ Telegram bot with functions tools.
 - `read_google_sheet` - read Google Sheet
 - `read_knowledge_google_sheet` - questions and answers from Google Sheet
 - `read_knowledge_json` - questions and answers from json file/url
-- `search_memory` - search messages saved with vector memory
+- `memory_search` - search messages saved with vector memory
+- `memory_delete` - delete messages from vector memory
 - `ssh_command` - exec ssh shell command, single server from config
 - `web_search_preview` - use OpenAI internal web search tool (only for Responses API)
 - `image_generation` - generate images using OpenAI image model (only for Responses API)
@@ -436,7 +437,7 @@ Other useful chat parameters include:
 
 ## Vector memory
 
-Enable semantic memory with `chatParams.vector_memory`. Messages starting with `запомни` are embedded and stored in a SQLite database using `sqlite-vec`. Use the `search_memory` tool to find related snippets. Set `toolParams.vector_memory.alwaysSearch` to automatically search memory before answering.
+Enable semantic memory with `chatParams.vector_memory`. Messages starting with `запомни` are embedded and stored in a SQLite database using `sqlite-vec`. Use the `memory_search` tool to find related snippets or `memory_delete` to remove them. Set `toolParams.vector_memory.alwaysSearch` to automatically search memory before answering.
 
 ```yaml
 chatParams:

--- a/src/handlers/onTextMessage.ts
+++ b/src/handlers/onTextMessage.ts
@@ -70,7 +70,7 @@ export default async function onTextMessage(
     chat.chatParams?.vector_memory &&
     msg.text?.toLowerCase().startsWith("запомни")
   ) {
-    const text = msg.text.replace(/^запомни\s*/i, "");
+    const text = msg.text.replace(/^запомни[\s\p{P}]*/iu, "");
     await saveEmbedding({
       text,
       metadata: {

--- a/src/tools/memory_delete.ts
+++ b/src/tools/memory_delete.ts
@@ -33,33 +33,32 @@ export class MemoryDeleteClient extends AIFunctionsProvider {
     description,
     inputSchema: z.object({
       query: z.string().describe("Delete query"),
-      limit: z.number().optional().default(3),
+      limit: z.number().describe("Limit, set to 1 if not specified").optional().default(1),
     }),
   })
   async memory_delete({
     query,
-    limit = 3,
+    limit = 1,
   }: {
     query: string;
     limit?: number;
   }): Promise<ToolResponse> {
     const rows = await deleteEmbedding({ query, limit, chat: this.configChat });
     const content = rows.map((r) => `${r.date} ${r.text}`).join("\n");
-    if (this.configChat.id)
-      await sendTelegramMessage(
-        this.configChat.id,
-        `Удалено ${rows.length} записей`,
-        undefined,
-        undefined,
-        this.configChat,
-      );
+    await sendTelegramMessage(
+      this.thread.id,
+      `Удалено записей: ${rows.length}`,
+      undefined,
+      undefined,
+      this.configChat,
+    );
     return { content };
   }
 
   options_string(str: string) {
     const { query } = JSON.parse(str) as { query: string };
-    if (!query) return str;
-    return `**Memory delete:** \`${query}\``;
+    const text = query || "all";
+    return `**Memory delete:** \`${text}\``;
   }
 }
 

--- a/src/tools/memory_delete.ts
+++ b/src/tools/memory_delete.ts
@@ -1,0 +1,59 @@
+import { aiFunction, AIFunctionsProvider } from "@agentic/core";
+import { z } from "zod";
+import type {
+  ConfigChatType,
+  ToolResponse,
+  ThreadStateType,
+} from "../types.ts";
+import { deleteEmbedding } from "../helpers/embeddings.ts";
+
+export const description = "Delete stored chat memory";
+export const details = `- deletes vector memory for similar snippets\n- dbPath: toolParams.vector_memory.dbPath`;
+
+export const defaultParams = {
+  vector_memory: {
+    dbPath: "data/memory/default.sqlite",
+    dimension: 1536,
+  },
+};
+
+export class MemoryDeleteClient extends AIFunctionsProvider {
+  protected readonly configChat: ConfigChatType;
+  protected readonly thread: ThreadStateType;
+
+  constructor(configChat: ConfigChatType, thread: ThreadStateType) {
+    super();
+    this.configChat = configChat;
+    this.thread = thread;
+  }
+
+  @aiFunction({
+    name: "memory_delete",
+    description,
+    inputSchema: z.object({
+      query: z.string().describe("Delete query"),
+      limit: z.number().optional().default(3),
+    }),
+  })
+  async memory_delete({
+    query,
+    limit = 3,
+  }: {
+    query: string;
+    limit?: number;
+  }): Promise<ToolResponse> {
+    const rows = await deleteEmbedding({ query, limit, chat: this.configChat });
+    const content = rows.map((r) => `${r.date} ${r.text}`).join("\n");
+    return { content };
+  }
+
+  options_string(str: string) {
+    const { query } = JSON.parse(str) as { query: string };
+    if (!query) return str;
+    return `**Memory delete:** \`${query}\``;
+  }
+}
+
+export function call(configChat: ConfigChatType, thread: ThreadStateType) {
+  return new MemoryDeleteClient(configChat, thread);
+}

--- a/src/tools/memory_delete.ts
+++ b/src/tools/memory_delete.ts
@@ -6,6 +6,7 @@ import type {
   ThreadStateType,
 } from "../types.ts";
 import { deleteEmbedding } from "../helpers/embeddings.ts";
+import { sendTelegramMessage } from "../telegram/send.ts";
 
 export const description = "Delete stored chat memory";
 export const details = `- deletes vector memory for similar snippets\n- dbPath: toolParams.vector_memory.dbPath`;
@@ -44,6 +45,14 @@ export class MemoryDeleteClient extends AIFunctionsProvider {
   }): Promise<ToolResponse> {
     const rows = await deleteEmbedding({ query, limit, chat: this.configChat });
     const content = rows.map((r) => `${r.date} ${r.text}`).join("\n");
+    if (this.configChat.id)
+      await sendTelegramMessage(
+        this.configChat.id,
+        `Удалено ${rows.length} записей`,
+        undefined,
+        undefined,
+        this.configChat,
+      );
     return { content };
   }
 

--- a/src/tools/memory_search.ts
+++ b/src/tools/memory_search.ts
@@ -50,8 +50,8 @@ export class MemorySearchClient extends AIFunctionsProvider {
 
   options_string(str: string) {
     const { query } = JSON.parse(str) as { query: string };
-    if (!query) return str;
-    return `**Memory search:** \`${query}\``;
+    const text = query || "all";
+    return `**Memory search:** \`${text}\``;
   }
 
   async prompt_append(): Promise<string | undefined> {

--- a/src/tools/memory_search.ts
+++ b/src/tools/memory_search.ts
@@ -18,7 +18,7 @@ export const defaultParams = {
   },
 };
 
-export class SearchMemoryClient extends AIFunctionsProvider {
+export class MemorySearchClient extends AIFunctionsProvider {
   protected readonly configChat: ConfigChatType;
   protected readonly thread: ThreadStateType;
 
@@ -29,14 +29,14 @@ export class SearchMemoryClient extends AIFunctionsProvider {
   }
 
   @aiFunction({
-    name: "search_memory",
+    name: "memory_search",
     description,
     inputSchema: z.object({
       query: z.string().describe("Search query"),
       limit: z.number().optional().default(3),
     }),
   })
-  async search_memory({
+  async memory_search({
     query,
     limit = 3,
   }: {
@@ -61,12 +61,12 @@ export class SearchMemoryClient extends AIFunctionsProvider {
       | undefined;
     const query = last?.text;
     if (!query) return;
-    const res = await this.search_memory({ query, limit: 3 });
+    const res = await this.memory_search({ query, limit: 3 });
     if (!res.content) return;
     return `## Related memory: <memory>${res.content}</memory>`;
   }
 }
 
 export function call(configChat: ConfigChatType, thread: ThreadStateType) {
-  return new SearchMemoryClient(configChat, thread);
+  return new MemorySearchClient(configChat, thread);
 }

--- a/tests/handlers/onTextMessageMemory.test.ts
+++ b/tests/handlers/onTextMessageMemory.test.ts
@@ -1,0 +1,115 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Context, Message } from "telegraf/types";
+import type { ConfigChatType } from "../../src/types";
+
+const threads: Record<
+  number,
+  {
+    id: number;
+    msgs: Message[];
+    messages: Message[];
+    completionParams: Record<string, unknown>;
+  }
+> = {
+  1: { id: 1, msgs: [], messages: [], completionParams: {} },
+};
+
+const mockCheckAccessLevel = jest.fn();
+const mockSaveEmbedding = jest.fn();
+const mockSendTelegramMessage = jest.fn();
+const mockResolveChatButtons = jest.fn();
+const mockAddToHistory = jest.fn();
+
+jest.unstable_mockModule("../../src/handlers/access.ts", () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockCheckAccessLevel(...args),
+}));
+
+jest.unstable_mockModule("../../src/helpers/embeddings.ts", () => ({
+  saveEmbedding: (...args: unknown[]) => mockSaveEmbedding(...args),
+}));
+
+jest.unstable_mockModule("../../src/helpers/history.ts", () => ({
+  addToHistory: (...args: unknown[]) => mockAddToHistory(...args),
+  forgetHistoryOnTimeout: jest.fn(),
+  forgetHistory: jest.fn(),
+  initThread: jest.fn(() => ({
+    id: 1,
+    msgs: [],
+    messages: [],
+    completionParams: {},
+  })),
+}));
+
+jest.unstable_mockModule("../../src/handlers/resolveChatButtons.ts", () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockResolveChatButtons(...args),
+}));
+
+jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
+  sendTelegramMessage: (...args: unknown[]) => mockSendTelegramMessage(...args),
+  sendTelegramDocument: jest.fn(),
+  getFullName: jest.fn(),
+  getTelegramForwardedUser: jest.fn(),
+  isAdminUser: jest.fn(),
+  buildButtonRows: jest.fn(),
+  isOurUser: jest.fn(),
+}));
+
+jest.unstable_mockModule("../../src/threads.ts", () => ({
+  useThreads: () => threads,
+}));
+
+let onTextMessage: (ctx: Context & { secondTry?: boolean }) => Promise<void>;
+
+function createCtx(
+  message: Record<string, unknown>,
+): Context & { secondTry?: boolean } {
+  return {
+    message,
+    update: { message },
+    persistentChatAction: async (_: string, fn: () => Promise<void>) => {
+      await fn();
+    },
+  } as unknown as Context & { secondTry?: boolean };
+}
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  jest.resetModules();
+  onTextMessage = (await import("../../src/handlers/onTextMessage.ts")).default;
+});
+
+describe("onTextMessage memory", () => {
+  it("saves embedding without punctuation", async () => {
+    const msg = {
+      chat: { id: 1, title: "t" },
+      from: { id: 2 },
+      text: "запомни: hello world",
+      message_id: 42,
+    } as Message.TextMessage;
+    const chat: ConfigChatType = {
+      name: "c",
+      id: 1,
+      completionParams: {},
+      chatParams: { vector_memory: true },
+      toolParams: {},
+    } as ConfigChatType;
+    mockCheckAccessLevel.mockResolvedValue({ msg, chat });
+    const ctx = createCtx(msg);
+    await onTextMessage(ctx);
+    expect(mockSaveEmbedding).toHaveBeenCalledWith({
+      text: "hello world",
+      metadata: { chatId: 1, userId: 2, messageId: 42 },
+      chat,
+    });
+    expect(mockSendTelegramMessage).toHaveBeenCalledWith(
+      1,
+      "Запомнил",
+      undefined,
+      ctx,
+      chat,
+    );
+    expect(mockAddToHistory).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tools/memory_delete.test.ts
+++ b/tests/tools/memory_delete.test.ts
@@ -1,0 +1,58 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import type { ConfigChatType, ThreadStateType } from "../../src/types";
+
+jest.unstable_mockModule("../../src/helpers/useApi.ts", () => ({
+  useApi: () => ({
+    embeddings: {
+      create: async () => ({ data: [{ embedding: [0.1, 0.2, 0.3] }] }),
+    },
+  }),
+}));
+
+let embeddings: typeof import("../../src/helpers/embeddings.ts");
+let mod: typeof import("../../src/tools/memory_delete.ts");
+
+function cfg(dbPath: string): ConfigChatType {
+  return {
+    name: "c",
+    agent_name: "a",
+    completionParams: {},
+    chatParams: { vector_memory: true },
+    toolParams: { vector_memory: { dbPath, dimension: 3 } },
+  } as ConfigChatType;
+}
+
+beforeEach(async () => {
+  jest.resetModules();
+  embeddings = await import("../../src/helpers/embeddings.ts");
+  mod = await import("../../src/tools/memory_delete.ts");
+});
+
+describe("memory_delete", () => {
+  it("deletes matching entries", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vec-"));
+    const db = path.join(dir, "db.sqlite");
+    const chat = cfg(db);
+    const thread: ThreadStateType = {
+      id: 1,
+      msgs: [],
+      messages: [],
+      completionParams: {},
+    } as ThreadStateType;
+    await embeddings.saveEmbedding({ text: "hello world", metadata: {}, chat });
+    const client = new mod.MemoryDeleteClient(chat, thread);
+    const res = await client.memory_delete({ query: "hello", limit: 1 });
+    expect(res.content).toContain("hello world");
+    const rows = await embeddings.searchEmbedding({
+      query: "hello",
+      limit: 1,
+      chat,
+    });
+    expect(rows).toHaveLength(0);
+    embeddings.closeDb(db);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/tests/tools/memory_search.test.ts
+++ b/tests/tools/memory_search.test.ts
@@ -13,7 +13,7 @@ jest.unstable_mockModule("../../src/helpers/useApi.ts", () => ({
 }));
 
 let embeddings: typeof import("../../src/helpers/embeddings.ts");
-let mod: typeof import("../../src/tools/search_memory.ts");
+let mod: typeof import("../../src/tools/memory_search.ts");
 
 function cfg(dbPath: string): ConfigChatType {
   return {
@@ -28,10 +28,10 @@ function cfg(dbPath: string): ConfigChatType {
 beforeEach(async () => {
   jest.resetModules();
   embeddings = await import("../../src/helpers/embeddings.ts");
-  mod = await import("../../src/tools/search_memory.ts");
+  mod = await import("../../src/tools/memory_search.ts");
 });
 
-describe("search_memory", () => {
+describe("memory_search", () => {
   it("inserts and searches", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vec-"));
     const db = path.join(dir, "db.sqlite");
@@ -43,8 +43,8 @@ describe("search_memory", () => {
       completionParams: {},
     } as ThreadStateType;
     await embeddings.saveEmbedding({ text: "hello world", metadata: {}, chat });
-    const client = new mod.SearchMemoryClient(chat, thread);
-    const res = await client.search_memory({ query: "hello", limit: 1 });
+    const client = new mod.MemorySearchClient(chat, thread);
+    const res = await client.memory_search({ query: "hello", limit: 1 });
     expect(res.content).toContain("hello world");
     embeddings.closeDb(db);
     fs.rmSync(dir, { recursive: true, force: true });

--- a/tests/vector_memory.test.ts
+++ b/tests/vector_memory.test.ts
@@ -34,19 +34,19 @@ function baseChat(): ConfigChatType {
 function writeChat(chat: ConfigChatType) {
   const config = generateConfig();
   config.chats.push(chat);
-  writeConfig("test-config.yml", config);
+  writeConfig("data/test-config.yml", config);
 }
 
 beforeEach(async () => {
   jest.resetModules();
-  process.env.CONFIG = "test-config.yml";
-  setConfigPath("test-config.yml");
+  process.env.CONFIG = "data/test-config.yml";
+  setConfigPath("data/test-config.yml");
   embeddings = await import("../src/helpers/embeddings.ts");
 });
 
 afterEach(() => {
-  fs.rmSync("data", { recursive: true, force: true });
-  fs.rmSync("test-config.yml", { force: true });
+  // Don't remove directories, only clean up specific files
+  fs.rmSync("data/test-config.yml", { force: true });
   delete process.env.CONFIG;
   setConfigPath("config.yml");
 });
@@ -60,6 +60,8 @@ describe("defaultMemoryDbPath", () => {
     expect(fs.existsSync(expected)).toBe(true);
     expect(chat.toolParams?.vector_memory?.dbPath).toBe(expected);
     embeddings.closeDb(expected);
+    // Clean up the specific database file for this test
+    fs.rmSync(expected, { force: true });
   });
 
   it("uses bot_name for bot chats", async () => {
@@ -70,6 +72,8 @@ describe("defaultMemoryDbPath", () => {
     expect(fs.existsSync(expected)).toBe(true);
     expect(chat.toolParams?.vector_memory?.dbPath).toBe(expected);
     embeddings.closeDb(expected);
+    // Clean up the specific database file for this test
+    fs.rmSync(expected, { force: true });
   });
 
   it("uses sanitized group name for group chats", async () => {
@@ -80,6 +84,8 @@ describe("defaultMemoryDbPath", () => {
     expect(fs.existsSync(expected)).toBe(true);
     expect(chat.toolParams?.vector_memory?.dbPath).toBe(expected);
     embeddings.closeDb(expected);
+    // Clean up the specific database file for this test
+    fs.rmSync(expected, { force: true });
   });
 
   it("allows Cyrillic characters in group name", async () => {
@@ -90,6 +96,8 @@ describe("defaultMemoryDbPath", () => {
     expect(fs.existsSync(expected)).toBe(true);
     expect(chat.toolParams?.vector_memory?.dbPath).toBe(expected);
     embeddings.closeDb(expected);
+    // Clean up the specific database file for this test
+    fs.rmSync(expected, { force: true });
   });
 
   it("falls back to chat id when name sanitizes empty", async () => {
@@ -100,5 +108,7 @@ describe("defaultMemoryDbPath", () => {
     expect(fs.existsSync(expected)).toBe(true);
     expect(chat.toolParams?.vector_memory?.dbPath).toBe(expected);
     embeddings.closeDb(expected);
+    // Clean up the specific database file for this test
+    fs.rmSync(expected, { force: true });
   });
 });


### PR DESCRIPTION
## Summary
- rename search_memory tool to memory_search
- add memory_delete tool to remove chat memory entries
- document vector memory tools and add tests

## Testing
- `npm run format`
- `npm run typecheck`
- `npm run test-full`
- `npm run coverage-info`


------
https://chatgpt.com/codex/tasks/task_e_688e1243b24c832c8a2e2caa5ef37c17