### PR TITLE
Add telegram confirmation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,3 +481,22 @@ npm test
 ```
 
 This will execute all unit and integration tests in the `tests` directory using the `jest` framework.
+
+## Telegram utilities
+
+### telegram_confirm
+
+Helper to ask a user for confirmation with inline Yes/No buttons.
+
+```ts
+import { telegram_confirm } from "./telegram/confirm";
+
+await telegram_confirm(
+  chatId,
+  message,
+  chatConfig,
+  "Are you sure?",
+  async () => {/* confirmed */},
+  async () => {/* canceled */},
+);
+```

--- a/src/telegram/confirm.ts
+++ b/src/telegram/confirm.ts
@@ -1,0 +1,79 @@
+import { Context } from "telegraf";
+import { Message } from "telegraf/types";
+import { useBot } from "../bot.ts";
+import { sendTelegramMessage } from "./send.ts";
+import { ConfigChatType } from "../types.ts";
+
+/**
+ * Send confirmation request with inline buttons and resolve based on user choice.
+ *
+ * @param chatId chat identifier
+ * @param msg original message for user context
+ * @param chatConfig chat configuration
+ * @param text confirmation text
+ * @param onConfirm callback executed when user confirms
+ * @param onCancel callback executed when user cancels
+ * @param noSendTelegram optional flag to skip Telegram message sending
+ */
+export async function telegram_confirm<T>(
+  chatId: number,
+  msg: Message.TextMessage,
+  chatConfig: ConfigChatType,
+  text: string,
+  onConfirm: () => Promise<T> | T,
+  onCancel: () => Promise<T> | T,
+  noSendTelegram = false,
+): Promise<T> {
+  const id = Date.now().toString();
+  const confirmAction = `confirm_${id}`;
+  const cancelAction = `cancel_${id}`;
+
+  if (!noSendTelegram) {
+    await sendTelegramMessage(
+      chatId,
+      text,
+      {
+        reply_markup: {
+          inline_keyboard: [
+            [
+              { text: "Yes", callback_data: confirmAction },
+              { text: "No", callback_data: cancelAction },
+            ],
+          ],
+        },
+      },
+      undefined,
+      chatConfig,
+    );
+  }
+
+  return new Promise<T>((resolve) => {
+    useBot(chatConfig.bot_token!).action(
+      confirmAction,
+      async (ctx: Context) => {
+        if (ctx.from?.id !== msg.from?.id) return;
+        await ctx.answerCbQuery();
+        const res = await onConfirm();
+        resolve(res);
+      },
+    );
+
+    useBot(chatConfig.bot_token!).action(cancelAction, async (ctx: Context) => {
+      if (ctx.from?.id !== msg.from?.id) return;
+      await ctx.answerCbQuery();
+      if (!noSendTelegram) {
+        await sendTelegramMessage(
+          chatId,
+          "Action canceled.",
+          undefined,
+          ctx,
+          chatConfig,
+        );
+      }
+      const res = await onCancel();
+      resolve(res);
+    });
+  });
+}
+
+export default telegram_confirm;

--- a/tests/telegram/confirm.test.ts
+++ b/tests/telegram/confirm.test.ts
@@ -1,0 +1,98 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { Message } from "telegraf/types";
+import type { ConfigChatType } from "../../src/types";
+
+const mockSendTelegramMessage = jest.fn();
+const actions: Record<string, (ctx: unknown) => Promise<void>> = {};
+
+jest.unstable_mockModule("../../src/telegram/send.ts", () => ({
+  __esModule: true,
+  sendTelegramMessage: (...args: unknown[]) => mockSendTelegramMessage(...args),
+}));
+
+jest.unstable_mockModule("../../src/bot.ts", () => ({
+  __esModule: true,
+  useBot: () => ({
+    action: (name: string, cb: (ctx: unknown) => Promise<void>) => {
+      actions[name] = cb;
+    },
+  }),
+}));
+
+let telegram_confirm: typeof import("../../src/telegram/confirm.ts").telegram_confirm;
+
+function createMsg(): Message.TextMessage {
+  return {
+    chat: { id: 1, type: "private" },
+    from: { id: 10, username: "user" },
+    text: "hi",
+  } as Message.TextMessage;
+}
+
+function createChat(): ConfigChatType {
+  return {
+    bot_token: "token",
+    completionParams: {},
+    chatParams: {},
+    toolParams: {},
+  } as ConfigChatType;
+}
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockSendTelegramMessage.mockReset();
+  mockSendTelegramMessage.mockResolvedValue(undefined);
+  Object.keys(actions).forEach((k) => delete actions[k]);
+  ({ telegram_confirm } = await import("../../src/telegram/confirm.ts"));
+});
+
+describe("telegram_confirm", () => {
+  it("resolves with onConfirm on yes", async () => {
+    const msg = createMsg();
+    const chatConfig = createChat();
+    const resultPromise = telegram_confirm(
+      1,
+      msg,
+      chatConfig,
+      "Are you sure?",
+      async () => 42,
+      async () => 0,
+    );
+    await Promise.resolve();
+    expect(mockSendTelegramMessage).toHaveBeenCalled();
+    const confirmName = Object.keys(actions).find((n) =>
+      n.startsWith("confirm_"),
+    )!;
+    await actions[confirmName]({
+      chat: { id: 1 },
+      from: { id: 10 },
+      answerCbQuery: jest.fn(),
+    });
+    await expect(resultPromise).resolves.toBe(42);
+  });
+
+  it("resolves with onCancel on no and notifies", async () => {
+    const msg = createMsg();
+    const chatConfig = createChat();
+    const resultPromise = telegram_confirm(
+      1,
+      msg,
+      chatConfig,
+      "Are you sure?",
+      async () => 1,
+      async () => -1,
+    );
+    await Promise.resolve();
+    const cancelName = Object.keys(actions).find((n) =>
+      n.startsWith("cancel_"),
+    )!;
+    await actions[cancelName]({
+      chat: { id: 1 },
+      from: { id: 10 },
+      answerCbQuery: jest.fn(),
+    });
+    await expect(resultPromise).resolves.toBe(-1);
+    expect(mockSendTelegramMessage).toHaveBeenCalledTimes(2);
+    expect(mockSendTelegramMessage.mock.calls[1][1]).toBe("Action canceled.");
+  });
+});


### PR DESCRIPTION
## Summary
- add generic `telegram_confirm` helper for yes/no prompts
- document `telegram_confirm` usage in README
- cover confirm/cancel flows with unit tests

## Testing
- `npm run typecheck`
- `npm run test-full`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_688e4bcd9fd0832caf90a7af8b0f44ae