### PR TITLE
fix gpt tools tests

### DIFF
--- a/src/helpers/gpt/tools.ts
+++ b/src/helpers/gpt/tools.ts
@@ -62,7 +62,7 @@ export function chatAsTool({
   prompt_append,
   msg,
 }: ToolBotType & { msg: Message.TextMessage }): ChatToolType {
-  name = agent_name || safeFilename(name, "agent");
+  name = safeFilename(name || agent_name || "", "agent");
   return {
     name,
     module: {

--- a/tests/helpers/gptTools.test.ts
+++ b/tests/helpers/gptTools.test.ts
@@ -47,6 +47,7 @@ jest.unstable_mockModule("../../src/threads.ts", () => ({
 jest.unstable_mockModule("../../src/helpers.ts", () => ({
   log: (...args: unknown[]) => mockLog(...args),
   sendToHttp: (...args: unknown[]) => mockSendToHttp(...args),
+  safeFilename: jest.fn((v) => v),
 }));
 
 jest.unstable_mockModule("../../src/mqtt.ts", () => ({


### PR DESCRIPTION
## Summary
- preserve agent tool name by defaulting to provided name before sanitizing
- mock `safeFilename` in gpt tools tests

## Testing
- `npm run typecheck`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_6890c0419bac832c9b4c68fffb15a267