### PR TITLE
feat: add chat directory config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Empty `config.yml` should be generated. Fill it with your data:
 - auth.chatgpt_api_key
 - stt.whisperBaseUrl
 - http.http_token (per-chat tokens use chat.http_token)
+- useChatsDir (optional, default `false`)
+- chatsDir (optional, default `data/chats`)
 
 ### Multiple Bots / Secondary bot_token
 
@@ -499,7 +501,11 @@ await telegramConfirm({
   msg: message,
   chatConfig,
   text: "Are you sure?",
-  onConfirm: async () => {/* confirmed */},
-  onCancel: async () => {/* canceled */},
+  onConfirm: async () => {
+    /* confirmed */
+  },
+  onCancel: async () => {
+    /* canceled */
+  },
 });
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -118,6 +118,8 @@ export function generateConfig(): ConfigType {
       publicKey: "",
       baseUrl: "",
     },
+    useChatsDir: false,
+    chatsDir: "data/chats",
     chats: [
       {
         name: "default",

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,8 @@ export type ConfigType = {
     publicKey: string;
     baseUrl: string;
   };
+  useChatsDir?: boolean;
+  chatsDir?: string;
   chats: ConfigChatType[];
 };
 

--- a/testConfig.yml
+++ b/testConfig.yml
@@ -16,6 +16,8 @@ stt:
 vision:
   model: gpt-4.1-mini
 local_models: []
+useChatsDir: false
+chatsDir: data/chats
 chats:
   - name: default
     completionParams:

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -41,6 +41,14 @@ jest.unstable_mockModule("js-yaml", () => ({
 const configMod = await import("../src/config.ts");
 const { readConfig, writeConfig, generateConfig } = configMod;
 
+describe("generateConfig", () => {
+  it("sets defaults for chat directory fields", () => {
+    const cfg = generateConfig();
+    expect(cfg.useChatsDir).toBe(false);
+    expect(cfg.chatsDir).toBe("data/chats");
+  });
+});
+
 describe("readConfig", () => {
   beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
## Summary
- allow configuring external chat config directory with `useChatsDir` and `chatsDir`
- document new chat directory settings in README and sample config
- test default chat directory configuration

## Testing
- `npm run typecheck`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_6891a1be3144832c9dd7f452cda73171