### PR TITLE
feat(config): support chat configs directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ Empty `config.yml` should be generated. Fill it with your data:
 - auth.chatgpt_api_key
 - stt.whisperBaseUrl
 - http.http_token (per-chat tokens use chat.http_token)
-- useChatsDir (optional, default `false`)
-- chatsDir (optional, default `data/chats`)
+- useChatsDir (optional, default `false`) – when enabled, chat configs are loaded from separate files
+  inside `chatsDir` instead of the `chats` section of `config.yml`.
+- chatsDir (optional, default `data/chats`) – directory where per-chat YAML files are stored when
+  `useChatsDir` is turned on.
 
 ### Multiple Bots / Secondary bot_token
 

--- a/tests/configExtras.test.ts
+++ b/tests/configExtras.test.ts
@@ -10,6 +10,8 @@ const mockDebounce = jest.fn((fn) => fn);
 const mockUseThreads = jest.fn(() => ({}));
 const mockLoad = jest.fn();
 const mockDump = jest.fn((obj) => JSON.stringify(obj));
+const mockReaddirSync = jest.fn();
+const mockMkdirSync = jest.fn();
 
 jest.unstable_mockModule("../src/helpers.ts", () => ({
   log: mockLog,
@@ -43,11 +45,15 @@ jest.unstable_mockModule("fs", () => ({
     existsSync: mockExistsSync,
     readFileSync: mockReadFileSync,
     watchFile: mockWatchFile,
+    readdirSync: mockReaddirSync,
+    mkdirSync: mockMkdirSync,
   },
   writeFileSync: mockWriteFile,
   existsSync: mockExistsSync,
   readFileSync: mockReadFileSync,
   watchFile: mockWatchFile,
+  readdirSync: mockReaddirSync,
+  mkdirSync: mockMkdirSync,
 }));
 
 let mod: typeof import("../src/config.ts");
@@ -61,6 +67,8 @@ beforeEach(async () => {
   mockWatchFile.mockClear();
   mockExistsSync.mockClear();
   mockReadFileSync.mockClear();
+  mockReaddirSync.mockClear();
+  mockMkdirSync.mockClear();
   mod = await import("../src/config.ts");
 });
 

--- a/tests/googleHelpers.test.ts
+++ b/tests/googleHelpers.test.ts
@@ -6,6 +6,8 @@ const mockExistsSync = jest.fn();
 const mockReadFileSync = jest.fn();
 const mockWriteFileSync = jest.fn();
 const mockWatchFile = jest.fn();
+const mockMkdirSync = jest.fn();
+const mockReaddirSync = jest.fn();
 
 jest.unstable_mockModule("fs", () => ({
   __esModule: true,
@@ -14,11 +16,15 @@ jest.unstable_mockModule("fs", () => ({
     readFileSync: mockReadFileSync,
     writeFileSync: mockWriteFileSync,
     watchFile: mockWatchFile,
+    mkdirSync: mockMkdirSync,
+    readdirSync: mockReaddirSync,
   },
   existsSync: mockExistsSync,
   readFileSync: mockReadFileSync,
   writeFileSync: mockWriteFileSync,
   watchFile: mockWatchFile,
+  mkdirSync: mockMkdirSync,
+  readdirSync: mockReaddirSync,
 }));
 
 let googleHelpers: typeof import("../src/helpers/google.ts");
@@ -28,6 +34,8 @@ beforeEach(async () => {
   mockExistsSync.mockReset();
   mockReadFileSync.mockReset();
   mockWriteFileSync.mockReset();
+  mockMkdirSync.mockReset();
+  mockReaddirSync.mockReset();
   googleHelpers = await import("../src/helpers/google.ts");
 });
 

--- a/tests/telegram/sendMessageExtra.test.ts
+++ b/tests/telegram/sendMessageExtra.test.ts
@@ -13,6 +13,7 @@ jest.unstable_mockModule("../../src/bot.ts", () => ({
 
 jest.unstable_mockModule("../../src/helpers.ts", () => ({
   log: jest.fn(),
+  safeFilename: jest.fn((v) => v),
 }));
 
 // mock splitBigMessage so we control number of parts


### PR DESCRIPTION
## Summary
- add helpers to load and save per-chat configs from directory
- wire config reading and writing to handle `useChatsDir`
- document chat directory mode and add coverage tests

## Testing
- `npm run typecheck`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_6891ab743fd8832cbf653fe80f2a794e