### PR TITLE
feat: add chat config converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Empty `config.yml` should be generated. Fill it with your data:
 - chatsDir (optional, default `data/chats`) – directory where per-chat YAML files are stored when
   `useChatsDir` is turned on.
 
+You can convert your configuration between a single `config.yml` and per-chat files:
+
+```bash
+npm run config:convert split   # save chats to data/chats and enable useChatsDir
+npm run config:convert merge   # read chats from data/chats and merge into config.yml
+```
+
 ### Multiple Bots / Secondary bot_token
 
 You can run multiple Telegram bots from a single instance using the `bot_token` field in each chat config.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "format": "prettier -l --write \"src/**/*.{ts,js,json,md}\" \"tests/**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"src/**/*.{ts,js,json,md}\" \"tests/**/*.{ts,js,json,md}\"",
     "agent": "tsx src/cli-agent.ts",
+    "config:convert": "tsx src/cli-config.ts",
     "healthcheck": "tsx src/healthcheck.ts"
   },
   "author": "",

--- a/src/cli-config.ts
+++ b/src/cli-config.ts
@@ -1,0 +1,24 @@
+import { convertChatConfig } from "./config.ts";
+import { fileURLToPath } from "url";
+import { resolve } from "path";
+
+export const runConfigConvert = (args: string[]) => {
+  const [mode] = args as Array<"split" | "merge">;
+  if (mode !== "split" && mode !== "merge") {
+    console.error("Usage: npm run config:convert <split|merge>");
+    process.exit(1);
+  }
+  convertChatConfig(mode);
+};
+
+const isMain = (() => {
+  const currentFilePath = fileURLToPath(import.meta.url);
+  const scriptPath = process.argv[1]
+    ? resolve(process.cwd(), process.argv[1])
+    : "";
+  return scriptPath === currentFilePath;
+})();
+
+if (isMain) {
+  runConfigConvert(process.argv.slice(2));
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,6 +53,22 @@ export function saveChatsToDir(dir: string, chats: ConfigChatType[]) {
   });
 }
 
+export function convertChatConfig(mode: "split" | "merge") {
+  const cfg = readConfig(configPath);
+  const dir = cfg.chatsDir || "data/chats";
+
+  if (mode === "split") {
+    cfg.useChatsDir = true;
+    cfg.chatsDir = dir;
+  } else {
+    cfg.chats = loadChatsFromDir(dir);
+    cfg.useChatsDir = false;
+  }
+
+  writeConfig(configPath, cfg);
+  return cfg;
+}
+
 export function readConfig(path?: string): ConfigType {
   if (!path) path = process.env.CONFIG || "config.yml";
   if (!existsSync(path)) {

--- a/tests/convertChatConfig.test.ts
+++ b/tests/convertChatConfig.test.ts
@@ -1,0 +1,116 @@
+import { jest } from "@jest/globals";
+import path from "path";
+import { ConfigChatType } from "../src/types.ts";
+
+const mockExistsSync = jest.fn();
+const mockReadFileSync = jest.fn();
+const mockWriteFileSync = jest.fn();
+const mockReaddirSync = jest.fn();
+const mockMkdirSync = jest.fn();
+const mockDump = jest.fn();
+const mockLoad = jest.fn();
+
+jest.unstable_mockModule("fs", () => ({
+  __esModule: true,
+  default: {
+    existsSync: mockExistsSync,
+    readFileSync: mockReadFileSync,
+    writeFileSync: mockWriteFileSync,
+    readdirSync: mockReaddirSync,
+    mkdirSync: mockMkdirSync,
+    watchFile: jest.fn(),
+    appendFileSync: jest.fn(),
+  },
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+  readdirSync: mockReaddirSync,
+  mkdirSync: mockMkdirSync,
+  watchFile: jest.fn(),
+  appendFileSync: jest.fn(),
+}));
+
+jest.unstable_mockModule("js-yaml", () => ({
+  __esModule: true,
+  dump: mockDump,
+  load: mockLoad,
+}));
+
+const { generateConfig, convertChatConfig } = await import("../src/config.ts");
+
+describe("convertChatConfig", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("splits chats into directory and enables useChatsDir", () => {
+    const cfg = generateConfig();
+    cfg.chats = [
+      {
+        name: "chat1",
+        completionParams: {},
+        chatParams: {},
+        toolParams: {},
+      } as ConfigChatType,
+    ];
+    cfg.useChatsDir = false;
+
+    mockExistsSync.mockReturnValueOnce(true).mockReturnValueOnce(false);
+    mockReadFileSync.mockReturnValueOnce("cfgYaml");
+    mockLoad.mockReturnValueOnce(cfg);
+    mockDump.mockReturnValueOnce("chatYaml").mockReturnValueOnce("cfgOut");
+
+    convertChatConfig("split");
+
+    expect(mockMkdirSync).toHaveBeenCalledWith("data/chats", {
+      recursive: true,
+    });
+    expect(mockWriteFileSync).toHaveBeenNthCalledWith(
+      1,
+      path.join("data/chats", "chat1.yml"),
+      "chatYaml",
+    );
+    expect(mockDump.mock.calls[1][0]).not.toHaveProperty("chats");
+    expect(mockDump.mock.calls[1][0]).toMatchObject({ useChatsDir: true });
+    expect(mockWriteFileSync).toHaveBeenNthCalledWith(
+      2,
+      "config.yml",
+      "cfgOut",
+    );
+  });
+
+  it("merges chats from directory and disables useChatsDir", () => {
+    const cfg = generateConfig();
+    cfg.useChatsDir = true;
+    cfg.chats = [];
+    const chat1 = { name: "a" } as ConfigChatType;
+    const chat2 = { name: "b" } as ConfigChatType;
+
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync
+      .mockReturnValueOnce("cfgYaml")
+      .mockReturnValueOnce("aYaml")
+      .mockReturnValueOnce("bYaml")
+      .mockReturnValueOnce("aYaml")
+      .mockReturnValueOnce("bYaml");
+    mockLoad
+      .mockReturnValueOnce(cfg)
+      .mockReturnValueOnce(chat1)
+      .mockReturnValueOnce(chat2)
+      .mockReturnValueOnce(chat1)
+      .mockReturnValueOnce(chat2);
+    mockReaddirSync.mockReturnValue(["a.yml", "b.yml"]);
+    mockDump.mockReturnValue("cfgOut");
+
+    convertChatConfig("merge");
+
+    expect(mockReaddirSync).toHaveBeenCalledWith("data/chats");
+    expect(mockDump).toHaveBeenCalledTimes(1);
+    expect(mockDump.mock.calls[0][0]).toMatchObject({
+      useChatsDir: false,
+      chats: [chat1, chat2],
+    });
+    expect(mockWriteFileSync).toHaveBeenCalledWith("config.yml", "cfgOut");
+    expect(mockMkdirSync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `convertChatConfig` utility to split/merge chat configs
- expose CLI command `config:convert` for config conversions
- document configuration converter usage

## Testing
- `npm run format`
- `npm run typecheck`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_6891b6335034832cbddf44cfbd5a393a