### PR TITLE
feat(config): watch chat files and avoid redundant writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ Empty `config.yml` should be generated. Fill it with your data:
 - chatsDir (optional, default `data/chats`) – directory where per-chat YAML files are stored when
   `useChatsDir` is turned on.
 
+When `useChatsDir` is enabled, the bot watches both `config.yml` and each chat file for changes and
+automatically reloads updated settings. New chat files placed in the directory are also watched
+automatically. Configuration files are written only when their content changes to avoid unnecessary
+reloads.
+
 You can convert your configuration between a single `config.yml` and per-chat files:
 
 ```bash

--- a/tests/configExtras.test.ts
+++ b/tests/configExtras.test.ts
@@ -121,8 +121,12 @@ describe("logConfigChanges", () => {
     const oldCfg = mod.generateConfig();
     const newCfg = mod.generateConfig();
     newCfg.bot_name = "new";
-    mod.logConfigChanges(oldCfg, newCfg);
-    expect(mockLog).toHaveBeenCalled();
+    mod.logConfigChanges(oldCfg, newCfg, "config.yml");
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg: expect.stringContaining("config.yml"),
+      }),
+    );
     expect(mockWriteFile).toHaveBeenCalledWith(
       "data/last-config-change.diff",
       expect.any(String),
@@ -131,7 +135,7 @@ describe("logConfigChanges", () => {
 
   it("does nothing when configs equal", () => {
     const cfg = mod.generateConfig();
-    mod.logConfigChanges(cfg, cfg);
+    mod.logConfigChanges(cfg, cfg, "config.yml");
     expect(mockLog).not.toHaveBeenCalled();
     expect(mockWriteFile).not.toHaveBeenCalled();
   });
@@ -143,8 +147,12 @@ describe("logConfigChanges", () => {
     const newCfg = mod.generateConfig();
     newCfg.useChatsDir = true;
     newCfg.chats = [{ name: "test", agent_name: "b" } as ConfigChatType];
-    mod.logConfigChanges(oldCfg, newCfg);
-    expect(mockLog).toHaveBeenCalled();
+    mod.logConfigChanges(oldCfg, newCfg, "data/chats/test.yml");
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg: expect.stringContaining("data/chats/test.yml"),
+      }),
+    );
     expect(mockWriteFile).toHaveBeenCalledWith(
       "data/last-config-change.diff",
       expect.any(String),

--- a/tests/convertChatConfig.test.ts
+++ b/tests/convertChatConfig.test.ts
@@ -9,6 +9,7 @@ const mockReaddirSync = jest.fn();
 const mockMkdirSync = jest.fn();
 const mockDump = jest.fn();
 const mockLoad = jest.fn();
+const mockWatch = jest.fn();
 
 jest.unstable_mockModule("fs", () => ({
   __esModule: true,
@@ -19,6 +20,7 @@ jest.unstable_mockModule("fs", () => ({
     readdirSync: mockReaddirSync,
     mkdirSync: mockMkdirSync,
     watchFile: jest.fn(),
+    watch: mockWatch,
     appendFileSync: jest.fn(),
   },
   existsSync: mockExistsSync,
@@ -27,6 +29,7 @@ jest.unstable_mockModule("fs", () => ({
   readdirSync: mockReaddirSync,
   mkdirSync: mockMkdirSync,
   watchFile: jest.fn(),
+  watch: mockWatch,
   appendFileSync: jest.fn(),
 }));
 

--- a/tests/googleHelpers.test.ts
+++ b/tests/googleHelpers.test.ts
@@ -6,6 +6,7 @@ const mockExistsSync = jest.fn();
 const mockReadFileSync = jest.fn();
 const mockWriteFileSync = jest.fn();
 const mockWatchFile = jest.fn();
+const mockWatch = jest.fn();
 const mockMkdirSync = jest.fn();
 const mockReaddirSync = jest.fn();
 
@@ -16,6 +17,7 @@ jest.unstable_mockModule("fs", () => ({
     readFileSync: mockReadFileSync,
     writeFileSync: mockWriteFileSync,
     watchFile: mockWatchFile,
+    watch: mockWatch,
     mkdirSync: mockMkdirSync,
     readdirSync: mockReaddirSync,
   },
@@ -23,6 +25,7 @@ jest.unstable_mockModule("fs", () => ({
   readFileSync: mockReadFileSync,
   writeFileSync: mockWriteFileSync,
   watchFile: mockWatchFile,
+  watch: mockWatch,
   mkdirSync: mockMkdirSync,
   readdirSync: mockReaddirSync,
 }));
@@ -36,6 +39,7 @@ beforeEach(async () => {
   mockWriteFileSync.mockReset();
   mockMkdirSync.mockReset();
   mockReaddirSync.mockReset();
+  mockWatch.mockReset();
   googleHelpers = await import("../src/helpers/google.ts");
 });
 


### PR DESCRIPTION
## Summary
- watch chat config files when `useChatsDir` is enabled
- skip rewriting config files if contents are unchanged
- automatically watch newly created chat config files
- document automatic config watching and conditional writes

## Testing
- `npm test`
- `npm run coverage-info`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_689312e12480832c9ef290672dd4c3af