### PR TITLE
Ensure private chats use username-based config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Empty `config.yml` should be generated. Fill it with your data:
 - useChatsDir (optional, default `false`) – when enabled, chat configs are loaded from separate files
   inside `chatsDir` instead of the `chats` section of `config.yml`.
 - chatsDir (optional, default `data/chats`) – directory where per-chat YAML files are stored when
-  `useChatsDir` is turned on.
+  `useChatsDir` is turned on. Private chats are saved as `private_<username>.yml`.
 
 When `useChatsDir` is enabled, the bot watches both `config.yml` and each chat file for changes and
 automatically reloads updated settings. New chat files placed in the directory are also watched

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,7 +54,10 @@ export function saveChatsToDir(dir: string, chats: ConfigChatType[]) {
     mkdirSync(dir, { recursive: true });
   }
   chats.forEach((chat) => {
-    const safe = safeFilename(`${chat.name || chat.id}`, `${chat.id || 0}`);
+    const nameForFile = chat.username
+      ? `private_${chat.username}`
+      : `${chat.name || chat.id}`;
+    const safe = safeFilename(nameForFile, `${chat.id || 0}`);
     const filePath = path.join(dir, `${safe}.yml`);
     const yamlRaw = yaml.dump(chat, {
       lineWidth: -1,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -287,6 +287,26 @@ describe("saveChatsToDir", () => {
     saveChatsToDir("dir", chats);
     expect(mockWriteFileSync).not.toHaveBeenCalled();
   });
+
+  it("uses private_<username>.yml for private chats", () => {
+    mockExistsSync.mockReturnValue(false);
+    const chats = [
+      {
+        name: "Private alice",
+        username: "alice",
+        completionParams: {},
+        chatParams: {},
+        toolParams: {},
+      } as ConfigChatType,
+    ];
+    mockDump.mockReturnValueOnce("ayaml");
+    saveChatsToDir("dir", chats);
+    expect(mockMkdirSync).toHaveBeenCalledWith("dir", { recursive: true });
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      path.join("dir", "private_alice.yml"),
+      "ayaml",
+    );
+  });
 });
 
 describe("readConfig agent_name", () => {


### PR DESCRIPTION
## Summary
- derive private chat config filenames from the user name
- document private chat config filename pattern
- add tests for private chat file naming

## Testing
- `npm run format src tests`
- `npm run typecheck`
- `npm run test-full`
- `npm run coverage-info`


------
https://chatgpt.com/codex/tasks/task_e_6893cde58834832cb95c2d273a5ab29f