### PR TITLE
feat: allow chat response format

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Telegram bot with functions tools.
 - Optional delay between split messages
 - Vector memory with `memory_search` and `memory_delete` tools (confirmation required for delete, optional automatic search)
 - Dynamic reply buttons returned from LLM responses (enable with `chatParams.responseButtons`)
+- Enforce structured outputs by setting `response_format` in chat configuration
 
 ## Pipeline
 
@@ -491,6 +492,29 @@ chatParams:
 ```
 
 Each button should contain `name` and `prompt`. When a user clicks a button, its `prompt` is sent as their next message.
+
+## Default response format
+
+Set `response_format` in a chat configuration to force the model to reply in a specific structure.
+
+```yaml
+response_format:
+  type: json_object
+```
+
+You can also provide a JSON Schema:
+
+```yaml
+response_format:
+  type: json_schema
+  json_schema:
+    name: response
+    schema:
+      type: object
+      properties:
+        message: { type: string }
+      required: [message]
+```
 
 ## Langfuse Setup
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -252,6 +252,7 @@ export function generateConfig(): ConfigType {
           temperature: 0.7,
         },
         local_model: "",
+        response_format: { type: "json_object" },
         systemMessage: "You are using functions to answer the questions. Current date: {date}",
         buttons: [{ name: "button_name", prompt: "button_prompt" }],
         buttonsSync: {

--- a/src/helpers/gpt/llm.ts
+++ b/src/helpers/gpt/llm.ts
@@ -562,7 +562,7 @@ export async function requestGptAnswer(
     model,
     temperature: thread.completionParams?.temperature,
     tools,
-    response_format: options?.responseFormat,
+    response_format: options?.responseFormat || chatConfig.response_format,
   };
   const { res, trace, webSearchDetails, images } = await llmCall({
     apiParams,
@@ -613,7 +613,7 @@ export async function requestGptAnswer(
     noSendTelegram: ctx?.noSendTelegram,
     gptContext,
     trace,
-    responseFormat: options?.responseFormat,
+    responseFormat: options?.responseFormat || chatConfig.response_format,
   });
 
   if (!options?.skipEvaluators && chatConfig.evaluators?.length) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export type ConfigChatType = {
   prefix?: string;
   completionParams: CompletionParamsType;
   local_model?: string;
+  response_format?: OpenAI.Chat.Completions.ChatCompletionCreateParams["response_format"];
   systemMessage?: string;
   buttons?: ConfigChatButtonType[];
   buttonsSync?: ButtonsSyncConfigType;

--- a/tests/helpers/llm.extras.test.ts
+++ b/tests/helpers/llm.extras.test.ts
@@ -582,6 +582,24 @@ describe("requestGptAnswer", () => {
     expect(calledParams.tools).toEqual([{ type: "image_generation" }]);
   });
 
+  it("uses response_format from chat config", async () => {
+    const api = {
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue({ choices: [{ message: { content: "a" } }] }),
+        },
+      },
+    };
+    mockUseApi.mockReturnValue(api);
+    const msg: Message.TextMessage = { ...baseMsg };
+    await requestGptAnswer(msg, {
+      ...chatConfig,
+      response_format: { type: "json_object" },
+    });
+    const calledParams = (api.chat.completions.create as jest.Mock).mock.calls[0][0];
+    expect(calledParams.response_format).toEqual({ type: "json_object" });
+  });
+
   it("sends web search details", async () => {
     const api = {
       responses: {


### PR DESCRIPTION
## Summary
- allow per-chat `response_format`
- support configured `response_format` in GPT requests
- document response format usage

## Testing
- `npm run typecheck`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_68a5dfdff5d0832c93d58aae948c24d0